### PR TITLE
Add Flush() method to the StatsReporter interface

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -45,6 +45,10 @@ func (r *printStatsReporter) ReportTimer(name string, tags map[string]string, in
 	fmt.Printf("%s %d\n", name, interval)
 }
 
+func (r *printStatsReporter) Flush() {
+	fmt.Printf("Flush\n")
+}
+
 func main() {
 	reporter := newPrintStatsReporter()
 	rootScope := tally.NewRootScope("", nil, reporter, time.Second)

--- a/scope.go
+++ b/scope.go
@@ -52,6 +52,7 @@ type Scope interface {
 	// Tagged returns a new scope with the given tags
 	Tagged(tags map[string]string) Scope
 
+	// Report is the method that dumps a snapshot of all of the aggregated metrics into the StatsReporter via its Report* methods
 	Report(r StatsReporter)
 }
 
@@ -137,6 +138,8 @@ func (s *standardScope) Report(r StatsReporter) {
 	s.gm.RUnlock()
 
 	// we do nothing for timers here because timers report directly to ths StatsReporter without buffering
+
+	r.Flush()
 }
 
 // reportLoop is used by the root scope for periodic reporting

--- a/scope_test.go
+++ b/scope_test.go
@@ -50,6 +50,8 @@ func (r *testStatsReporter) ReportTimer(name string, tags map[string]string, int
 	r.timers[name] = interval
 }
 
+func (r *testStatsReporter) Flush() {}
+
 // newTestStatsReporter returns a new TestStatsReporter
 func newTestStatsReporter() *testStatsReporter {
 	return &testStatsReporter{

--- a/stats.go
+++ b/stats.go
@@ -31,6 +31,9 @@ type StatsReporter interface {
 	ReportCounter(name string, tags map[string]string, value int64)
 	ReportGauge(name string, tags map[string]string, value int64)
 	ReportTimer(name string, tags map[string]string, interval time.Duration)
+
+	// Flush is expected to be called by the Scope when it finishes a round or reporting
+	Flush()
 }
 
 type reportableMetric interface {
@@ -118,5 +121,6 @@ var NullStatsReporter StatsReporter = nullStatsReporter{}
 func (r nullStatsReporter) ReportCounter(name string, tags map[string]string, value int64)          {}
 func (r nullStatsReporter) ReportGauge(name string, tags map[string]string, value int64)            {}
 func (r nullStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {}
+func (r nullStatsReporter) Flush()                                                                  {}
 
 type nullStatsReporter struct{}


### PR DESCRIPTION
It is useful to the implementer to get notified of when the Scope just finished a bunch of work. They might choose to do nothing... but It is probably the case that you will want to flush a batch of data in a single network operation after Report is done, and it's way easier to add a Report method than to reimplement Scope.

@prashantv