### PR TITLE
Eliminate heap-allocation of Begin() timer function

### DIFF
--- a/scope_test.go
+++ b/scope_test.go
@@ -92,7 +92,8 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 	r := newTestStatsReporter()
 	scope := NewRootScope("", nil, r, 0)
 	r.tg.Add(1)
-	scope.Timer("ticky").Begin()()
+	tm := scope.Timer("ticky")
+	tm.Stop(tm.Start())
 	r.tg.Wait()
 }
 

--- a/stats.go
+++ b/stats.go
@@ -54,6 +54,7 @@ type Gauge interface {
 	Update(int64)
 }
 
+// StopwatchStart is returned by Timer.Start, and should be passed back to Timer.Stop() at the end of the interval
 type StopwatchStart time.Time
 
 // Timer is the interface for logging statsd-timer-type metrics

--- a/stats.go
+++ b/stats.go
@@ -54,9 +54,7 @@ type Gauge interface {
 	Update(int64)
 }
 
-type stopwatch struct {
-	startTime time.Time
-}
+type StopwatchStart time.Time
 
 // Timer is the interface for logging statsd-timer-type metrics
 type Timer interface {
@@ -65,10 +63,10 @@ type Timer interface {
 	Record(time.Duration)
 
 	// Start gives you back a specific point in time to report via Stop()
-	Start() stopwatch
+	Start() StopwatchStart
 
 	// Stop records the difference between the current clock and startTime
-	Stop(startTime stopwatch)
+	Stop(startTime StopwatchStart)
 }
 
 type counter struct {
@@ -115,12 +113,12 @@ func (g *gauge) report(name string, tags map[string]string, r StatsReporter) {
 	}
 }
 
-func (t *timer) Start() stopwatch {
-	return stopwatch{globalClock.Now()}
+func (t *timer) Start() StopwatchStart {
+	return StopwatchStart(globalClock.Now())
 }
 
-func (t *timer) Stop(sw stopwatch) {
-	t.reporter.ReportTimer(t.name, t.tags, globalClock.Now().Sub(sw.startTime))
+func (t *timer) Stop(sw StopwatchStart) {
+	t.reporter.ReportTimer(t.name, t.tags, globalClock.Now().Sub(time.Time(sw)))
 }
 
 func (t *timer) Record(interval time.Duration) {

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -53,7 +53,7 @@ func BenchmarkTimerInterval(b *testing.B) {
 		reporter: NullStatsReporter,
 	}
 	for n := 0; n < b.N; n++ {
-		t.Begin()() // call and imediately terminate
+		t.Stop(t.Start()) // start and stop
 	}
 }
 


### PR DESCRIPTION
This cuts BenchmarkTimerInterval from ~86ns to ~41ns

Seems reasonable to do while we have zero adoption.