### PR TITLE
Jra3/statsdreporter

### DIFF
--- a/statsd/reporter.go
+++ b/statsd/reporter.go
@@ -1,0 +1,63 @@
+package statsd
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/uber-go/tally"
+)
+
+type cactusStatsReporter struct {
+	statter  statsd.Statter
+	sm       sync.Mutex
+	scopes   []tally.Scope
+	interval time.Duration
+	quit     chan struct{}
+}
+
+// NewStatsdReporter wraps a statsd.Statter for use with tally
+func NewStatsdReporter(statsd statsd.Statter, interval time.Duration) tally.StatsReporter {
+	return &cactusStatsReporter{
+		quit:     make(chan struct{}),
+		statter:  statsd,
+		interval: interval,
+		scopes:   make([]tally.Scope, 0),
+	}
+}
+
+func (r *cactusStatsReporter) Start() {
+	ticker := time.NewTicker(r.interval)
+	for {
+		select {
+		case <-ticker.C:
+			for _, scope := range r.scopes {
+				scope.Report(r)
+			}
+		case <-r.quit:
+			return
+		}
+	}
+}
+
+func (r *cactusStatsReporter) registerScope(s tally.Scope) {
+	r.sm.Lock()
+	r.scopes = append(r.scopes, s)
+	r.sm.Unlock()
+}
+
+func (r *cactusStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	r.statter.Inc(name, value, 1.0)
+}
+
+func (r *cactusStatsReporter) ReportGauge(name string, tags map[string]string, value int64) {
+	r.statter.Gauge(name, value, 1.0)
+}
+
+func (r *cactusStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	r.statter.TimingDuration(name, interval, 1.0)
+}
+
+func (r *cactusStatsReporter) Flush() {
+	// no-op
+}

--- a/statsd/reporter.go
+++ b/statsd/reporter.go
@@ -16,7 +16,7 @@ type cactusStatsReporter struct {
 	quit     chan struct{}
 }
 
-// NewStatsdReporter wraps a statsd.Statter for use with tally
+// NewStatsdReporter wraps a statsd.Statter for use with tally. Use either statsd.NewClient or statsd.NewBufferedClient.
 func NewStatsdReporter(statsd statsd.Statter, interval time.Duration) tally.StatsReporter {
 	return &cactusStatsReporter{
 		quit:     make(chan struct{}),


### PR DESCRIPTION
This is meant to serve as the most barebones implementation of a reporter than just wraps the existing statsd client implementation from github.com/cactus/go-statsd-client/statsd

The caller just needs to create a Statter pointing to their correct server:port and wrap it up.