### PR TITLE
[counter] Use an atomic swap when reporting a counter

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -71,7 +71,6 @@ type Timer interface {
 }
 
 type counter struct {
-	prev int64
 	curr int64
 }
 
@@ -93,14 +92,12 @@ func (c *counter) Inc(v int64) {
 }
 
 func (c *counter) report(name string, tags map[string]string, r StatsReporter) {
-	curr := atomic.LoadInt64(&c.curr)
+	curr := atomic.SwapInt64(&c.curr, 0)
 
-	prev := c.prev
-	if prev == curr {
+	if curr == 0 {
 		return
 	}
-	atomic.StoreInt64(&c.prev, curr)
-	r.ReportCounter(name, tags, curr-prev)
+	r.ReportCounter(name, tags, curr)
 }
 
 func (g *gauge) Update(v int64) {


### PR DESCRIPTION
I believe the current implementation of `report` for a `counter` isn't goroutine safe but can be made safe if we use an atomic swap to get the current value of the counter and simultaneously set it to zero. This will preclude us from being able to keep a total count, however since we are only reporting the difference between `curr` and `prev` presently there won't be any semantic difference. 

---

I ran the benchmarks before and after the change and didn't see any appreciable difference:

Before

```
BenchmarkCounterInc-4                   100000000           10.0 ns/op
BenchmarkReportCounterNoData-4          200000000            6.32 ns/op
BenchmarkReportCounterWithData-4        50000000            26.9 ns/op
```

After

```
BenchmarkCounterInc-4                   100000000           11.9 ns/op
BenchmarkReportCounterNoData-4          100000000           12.0 ns/op
BenchmarkReportCounterWithData-4        100000000           23.8 ns/op
```

---

I believe we can report that a counter was incremented more than once if we call `report` from multiple goroutines. For example, consider the following execution of three goroutines: 

Initial State: `c.prev = 9, c.curr = 9`

Goroutine 1 calls `Inc` so now we have `c.prev = 9, c.curr = 10`

Goroutine 2 calls `report`:

```
    curr := atomic.LoadInt64(&c.curr)        // 10

    prev := c.prev   // 9
    * sleeps *
```

Goroutine 3 calls `report`

```
    curr := atomic.LoadInt64(&c.curr)    // 10

    prev := c.prev    // 9
    if prev == curr { 
        return
    }
    atomic.StoreInt64(&c.prev, curr)
    r.ReportCounter(name, tags, curr-prev) // reports a 1
```

Goroutine 2 rescheduled:

```
    if prev == curr {     // 9 == 10
        return
    }
    atomic.StoreInt64(&c.prev, curr)
    r.ReportCounter(name, tags, curr-prev) // reports a 1
```

If we use an atomic swap, however, only the first goroutine to call swap will see the increment, the other will see zero and not report anything.
