### PR TITLE
Allow access to the underlying reporter

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -54,6 +54,9 @@ type Scope interface {
 
 	// Report is the method that dumps a snapshot of all of the aggregated metrics into the StatsReporter via its Report* methods
 	Report(r StatsReporter)
+
+	// Reporter returns the underlying stats reporter which was used to initiate the Scope
+	Reporter() StatsReporter
 }
 
 // RootScope is a scope that manages itself and other Scopes
@@ -264,6 +267,10 @@ func (s *standardScope) SubScope(prefix string) Scope {
 
 	subscope.registry.add(subscope)
 	return subscope
+}
+
+func (s *standardScope) Reporter() StatsReporter {
+	return s.reporter
 }
 
 func (s *standardScope) fullyQualifiedName(name string) string {

--- a/scope_test.go
+++ b/scope_test.go
@@ -236,6 +236,12 @@ func TestTaggedSubScope(t *testing.T) {
 	}, r.counters["foo.boop"].tags)
 }
 
+func TestReporter(t *testing.T) {
+	r := newTestStatsReporter()
+	scope := NewRootScope("prefix", nil, r, 0)
+	assert.Equal(t, r, scope.Reporter())
+}
+
 func TestNilTagMerge(t *testing.T) {
 	assert.Nil(t, nil, mergeRightTags(nil, nil))
 }


### PR DESCRIPTION
Something that's required by uberfx for backwards compatibility support with old metrics system