### PR TITLE
Add access to tags and prefix on the scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -57,6 +57,12 @@ type Scope interface {
 
 	// Reporter returns the underlying stats reporter which was used to initiate the Scope
 	Reporter() StatsReporter
+
+	// Tags returns the map of tags usef in Scope creation
+	Tags() map[string]string
+
+	// Prefix returns the prefix stirng used in Scope creation
+	Prefix() string
 }
 
 // RootScope is a scope that manages itself and other Scopes
@@ -271,6 +277,14 @@ func (s *standardScope) SubScope(prefix string) Scope {
 
 func (s *standardScope) Reporter() StatsReporter {
 	return s.reporter
+}
+
+func (s *standardScope) Tags() map[string]string {
+	return s.tags
+}
+
+func (s *standardScope) Prefix() string {
+	return s.prefix
 }
 
 func (s *standardScope) fullyQualifiedName(name string) string {

--- a/scope_test.go
+++ b/scope_test.go
@@ -238,8 +238,21 @@ func TestTaggedSubScope(t *testing.T) {
 
 func TestReporter(t *testing.T) {
 	r := newTestStatsReporter()
-	scope := NewRootScope("prefix", nil, r, 0)
+	scope := NewRootScope("", nil, r, 0)
 	assert.Equal(t, r, scope.Reporter())
+}
+
+func TestTags(t *testing.T) {
+	tags := map[string]string{
+		"foo": "bar",
+	}
+	scope := NewRootScope("", tags, newTestStatsReporter(), 0)
+	assert.Equal(t, tags, scope.Tags())
+}
+
+func TestPrefix(t *testing.T) {
+	scope := NewRootScope("prefix", nil, newTestStatsReporter(), 0)
+	assert.Equal(t, "prefix", scope.Prefix())
 }
 
 func TestNilTagMerge(t *testing.T) {


### PR DESCRIPTION
Similar to #11: allows to see which values were used during creation without having to remember them via other means