### PR TITLE
Stop pinning dependencies in glide.yaml

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 31fe24e56ca2f9d4b7adf1e039cda071aea42db95c0cfb7e81654456bfabefb6
-updated: 2016-10-21T14:09:29.39810001-07:00
+hash: 37b48d1af3133a64b54ff9eb84b8ab0ab4352234e2dc828d75cd502030535169
+updated: 2016-11-11T15:40:12.381539323-08:00
 imports:
 - name: github.com/cactus/go-statsd-client
   version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
@@ -17,23 +17,23 @@ testImports:
   subpackages:
   - spew
 - name: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  version: 3390df4df2787994aea98de825b964ac7944b817
   subpackages:
   - golint
 - name: github.com/mattn/goveralls
-  version: f4d273b02ce1b4e48acf3662b717aa987bfc4118
+  version: a63d65fe590e2c830e60ad260cde6755ce3482a5
 - name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
+  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
   - require
 - name: golang.org/x/tools
-  version: 3fe2afc9e626f32e91aff6eddb78b14743446865
+  version: a69656e0e2d271df86336e3f498cf180de2be9c4
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,32 +7,32 @@ import:
   - statsd
 
 - package: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+  version: master
 
 testImport:
 - package: github.com/axw/gocov
-  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  version: master
   subpackages:
   - gocov
 
 - package: github.com/mattn/goveralls
-  version: f4d273b02ce1b4e48acf3662b717aa987bfc4118
+  version: master
 
 - package: golang.org/x/tools
-  version: 3fe2afc9e626f32e91aff6eddb78b14743446865
+  version: master
   subpackages:
   - cover
 
 - package: github.com/golang/lint
-  version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
+  version: master
   subpackages:
   - golint
 
 - package: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
+  version: master
 
 - package: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: master
   subpackages:
   - assert
   - require


### PR DESCRIPTION
As part of glide's dependency resolution, consumers of tally will have to consider these specific versions. That's fine for semvers, but the specific revisions are too strict.