### PR TITLE
Implement Stopwatch as struct for nicer elapsed time measurement.

### DIFF
--- a/scope_test.go
+++ b/scope_test.go
@@ -102,7 +102,7 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 	s, _ := NewRootScope("", nil, r, 0)
 	r.tg.Add(1)
 	tm := s.Timer("ticky")
-	tm.Stop(tm.Start())
+	tm.Start().Stop()
 	r.tg.Wait()
 }
 

--- a/stats.go
+++ b/stats.go
@@ -134,12 +134,8 @@ func newTimer(name string, tags map[string]string, r StatsReporter) *timer {
 	return t
 }
 
-func (t *timer) Start() StopwatchStart {
-	return StopwatchStart(globalClock.Now())
-}
-
-func (t *timer) Stop(sw StopwatchStart) {
-	t.reporter.ReportTimer(t.name, t.tags, globalClock.Now().Sub(time.Time(sw)))
+func (t *timer) Start() Stopwatch {
+	return Stopwatch{start: globalClock.Now(), timer: t}
 }
 
 func (t *timer) Record(interval time.Duration) {

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -53,7 +53,7 @@ func BenchmarkTimerInterval(b *testing.B) {
 		reporter: NullStatsReporter,
 	}
 	for n := 0; n < b.N; n++ {
-		t.Stop(t.Start()) // start and stop
+		t.Start().Stop() // start and stop
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -62,15 +62,21 @@ type Timer interface {
 	Record(time.Duration)
 
 	// Start gives you back a specific point in time to report via Stop()
-	Start() StopwatchStart
-
-	// Stop records the difference between the current clock and startTime
-	Stop(startTime StopwatchStart)
+	Start() Stopwatch
 }
 
-// StopwatchStart is returned by a timer's start method, and should be passed
-// back to the timer's stop method at the end of the interval
-type StopwatchStart time.Time
+// Stopwatch is a helper convenience struct for nicer tracking of elapsed time
+type Stopwatch struct {
+	start time.Time
+	timer *timer
+}
+
+// Stop records the difference between the current clock and startTime
+func (s Stopwatch) Stop() time.Duration {
+	d := globalClock.Now().Sub(s.start)
+	s.timer.Record(d)
+	return d
+}
 
 // Capabilities is a description of metrics reporting capabilities
 type Capabilities interface {


### PR DESCRIPTION
This makes timer.Stop() API a bit nicer to use. Plus now you have ability to just pass Stopwatch to some other function without passing timer as well.