### PR TITLE
Add CachedReporter interface that supports pre allocation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ endif
 test:
 	go test -race $(PKGS)
 
+.PHONY: cover
+cover:
+	go test -cover -coverprofile cover.out -race .
+
 .PHONY: coveralls
 coveralls:
 	goveralls -service=travis-ci .

--- a/reporter.go
+++ b/reporter.go
@@ -39,3 +39,37 @@ type StatsReporter interface {
 	// Flush is expected to be called by a Scope when it completes a round or reporting
 	Flush()
 }
+
+// CachedStatsReporter is a backend for Scopes that pre allocates all
+// counter, gauges & timers. This is harder to implement but more performant
+type CachedStatsReporter interface {
+	// AllocateCounter pre allocates a counter data structure with name & tags.
+	AllocateCounter(name string, tags map[string]string) CachedCount
+
+	// AllocateGauge pre allocates a gauge data structure with name & tags.
+	AllocateGauge(name string, tags map[string]string) CachedGauge
+
+	// AllocateTimer pre allocates a timer data structure with name & tags.
+	AllocateTimer(name string, tags map[string]string) CachedTimer
+
+	// CachedCapabilities returns a description of metrics reporting capabilities
+	CachedCapabilities() Capabilities
+
+	// CachedFlush is expected to be called by a Scope when it completes a round or reporting
+	CachedFlush()
+}
+
+// CachedCount interface for reporting an individual counter
+type CachedCount interface {
+	ReportCount(value int64)
+}
+
+// CachedGauge interface for reporting an individual gauge
+type CachedGauge interface {
+	ReportGauge(value float64)
+}
+
+// CachedTimer interface for reporting an individual timer
+type CachedTimer interface {
+	ReportTimer(interval time.Duration)
+}

--- a/reporter.go
+++ b/reporter.go
@@ -22,14 +22,15 @@ package tally
 
 import "time"
 
-type baseStatsReporter interface {
+// BaseStatsReporter implements the shared reporter methods
+type BaseStatsReporter interface {
 	Capabilities() Capabilities
 	Flush()
 }
 
 // StatsReporter is a backend for Scopes to report metrics to
 type StatsReporter interface {
-	baseStatsReporter
+	BaseStatsReporter
 
 	// ReportCounter reports a counter value
 	ReportCounter(name string, tags map[string]string, value int64)
@@ -44,7 +45,7 @@ type StatsReporter interface {
 // CachedStatsReporter is a backend for Scopes that pre allocates all
 // counter, gauges & timers. This is harder to implement but more performant
 type CachedStatsReporter interface {
-	baseStatsReporter
+	BaseStatsReporter
 
 	// AllocateCounter pre allocates a counter data structure with name & tags.
 	AllocateCounter(name string, tags map[string]string) CachedCount

--- a/reporter.go
+++ b/reporter.go
@@ -22,8 +22,15 @@ package tally
 
 import "time"
 
+type baseStatsReporter interface {
+	Capabilities() Capabilities
+	Flush()
+}
+
 // StatsReporter is a backend for Scopes to report metrics to
 type StatsReporter interface {
+	baseStatsReporter
+
 	// ReportCounter reports a counter value
 	ReportCounter(name string, tags map[string]string, value int64)
 
@@ -32,17 +39,13 @@ type StatsReporter interface {
 
 	// ReportTimer reports a timer value
 	ReportTimer(name string, tags map[string]string, interval time.Duration)
-
-	// Capabilities returns a description of metrics reporting capabilities
-	Capabilities() Capabilities
-
-	// Flush is expected to be called by a Scope when it completes a round or reporting
-	Flush()
 }
 
 // CachedStatsReporter is a backend for Scopes that pre allocates all
 // counter, gauges & timers. This is harder to implement but more performant
 type CachedStatsReporter interface {
+	baseStatsReporter
+
 	// AllocateCounter pre allocates a counter data structure with name & tags.
 	AllocateCounter(name string, tags map[string]string) CachedCount
 
@@ -51,12 +54,6 @@ type CachedStatsReporter interface {
 
 	// AllocateTimer pre allocates a timer data structure with name & tags.
 	AllocateTimer(name string, tags map[string]string) CachedTimer
-
-	// CachedCapabilities returns a description of metrics reporting capabilities
-	CachedCapabilities() Capabilities
-
-	// CachedFlush is expected to be called by a Scope when it completes a round or reporting
-	CachedFlush()
 }
 
 // CachedCount interface for reporting an individual counter

--- a/scope.go
+++ b/scope.go
@@ -55,7 +55,7 @@ type scope struct {
 	tags           map[string]string
 	reporter       StatsReporter
 	cachedReporter CachedStatsReporter
-	baseReporter   baseStatsReporter
+	baseReporter   BaseStatsReporter
 
 	registry *scopeRegistry
 	quit     chan struct{}
@@ -121,7 +121,7 @@ func newRootScope(
 		sep = separator
 	}
 
-	var baseReporter baseStatsReporter
+	var baseReporter BaseStatsReporter
 	if reporter != nil {
 		baseReporter = reporter
 	} else if cachedReporter != nil {

--- a/scope_test.go
+++ b/scope_test.go
@@ -140,13 +140,7 @@ func (r *testStatsReporter) Capabilities() Capabilities {
 	return capabilitiesReportingNoTagging
 }
 
-func (r *testStatsReporter) CachedCapabilities() Capabilities {
-	return capabilitiesReportingNoTagging
-}
-
 func (r *testStatsReporter) Flush() {}
-
-func (r *testStatsReporter) CachedFlush() {}
 
 func TestWriteTimerImmediately(t *testing.T) {
 	r := newTestStatsReporter()

--- a/scope_test.go
+++ b/scope_test.go
@@ -29,13 +29,30 @@ import (
 )
 
 type testIntValue struct {
-	val  int64
-	tags map[string]string
+	val      int64
+	tags     map[string]string
+	reporter *testStatsReporter
+}
+
+func (m *testIntValue) ReportCount(value int64) {
+	m.val = value
+	m.reporter.cg.Done()
+}
+
+func (m *testIntValue) ReportTimer(interval time.Duration) {
+	m.val = int64(interval)
+	m.reporter.tg.Done()
 }
 
 type testFloatValue struct {
-	val  float64
-	tags map[string]string
+	val      float64
+	tags     map[string]string
+	reporter *testStatsReporter
+}
+
+func (m *testFloatValue) ReportGauge(value float64) {
+	m.val = value
+	m.reporter.gg.Done()
 }
 
 type testStatsReporter struct {
@@ -59,6 +76,18 @@ func newTestStatsReporter() *testStatsReporter {
 	}
 }
 
+func (r *testStatsReporter) AllocateCounter(
+	name string, tags map[string]string,
+) CachedCount {
+	counter := &testIntValue{
+		val:      0,
+		tags:     tags,
+		reporter: r,
+	}
+	r.counters[name] = counter
+	return counter
+}
+
 func (r *testStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
 	r.counters[name] = &testIntValue{
 		val:  value,
@@ -67,12 +96,36 @@ func (r *testStatsReporter) ReportCounter(name string, tags map[string]string, v
 	r.cg.Done()
 }
 
+func (r *testStatsReporter) AllocateGauge(
+	name string, tags map[string]string,
+) CachedGauge {
+	gauge := &testFloatValue{
+		val:      0,
+		tags:     tags,
+		reporter: r,
+	}
+	r.gauges[name] = gauge
+	return gauge
+}
+
 func (r *testStatsReporter) ReportGauge(name string, tags map[string]string, value float64) {
 	r.gauges[name] = &testFloatValue{
 		val:  value,
 		tags: tags,
 	}
 	r.gg.Done()
+}
+
+func (r *testStatsReporter) AllocateTimer(
+	name string, tags map[string]string,
+) CachedTimer {
+	timer := &testIntValue{
+		val:      0,
+		tags:     tags,
+		reporter: r,
+	}
+	r.timers[name] = timer
+	return timer
 }
 
 func (r *testStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
@@ -87,7 +140,13 @@ func (r *testStatsReporter) Capabilities() Capabilities {
 	return capabilitiesReportingNoTagging
 }
 
+func (r *testStatsReporter) CachedCapabilities() Capabilities {
+	return capabilitiesReportingNoTagging
+}
+
 func (r *testStatsReporter) Flush() {}
+
+func (r *testStatsReporter) CachedFlush() {}
 
 func TestWriteTimerImmediately(t *testing.T) {
 	r := newTestStatsReporter()
@@ -109,6 +168,23 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 func TestWriteReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
 	s, close := NewRootScope("", nil, r, 10, "")
+	defer close.Close()
+
+	r.cg.Add(1)
+	s.Counter("bar").Inc(1)
+	r.gg.Add(1)
+	s.Gauge("zed").Update(1)
+	r.tg.Add(1)
+	s.Timer("ticky").Record(time.Millisecond * 175)
+
+	r.cg.Wait()
+	r.gg.Wait()
+	r.tg.Wait()
+}
+
+func TestCachedReportLoop(t *testing.T) {
+	r := newTestStatsReporter()
+	s, close := NewCachedRootScope("", nil, r, 10, "")
 	defer close.Close()
 
 	r.cg.Add(1)
@@ -151,6 +227,29 @@ func TestWriteOnce(t *testing.T) {
 	assert.Nil(t, r.counters["bar"])
 	assert.Nil(t, r.gauges["zed"])
 	assert.Nil(t, r.timers["ticky"])
+}
+
+func TestCachedReporter(t *testing.T) {
+	r := newTestStatsReporter()
+
+	root, _ := NewCachedRootScope("", nil, r, 0, "")
+	s := root.(*scope)
+
+	r.cg.Add(1)
+	s.Counter("bar").Inc(1)
+	r.gg.Add(1)
+	s.Gauge("zed").Update(1)
+	r.tg.Add(1)
+	s.Timer("ticky").Record(time.Millisecond * 175)
+
+	s.cachedReport(r)
+	r.cg.Wait()
+	r.gg.Wait()
+	r.tg.Wait()
+
+	assert.EqualValues(t, 1, r.counters["bar"].val)
+	assert.EqualValues(t, 1, r.gauges["zed"].val)
+	assert.EqualValues(t, time.Millisecond*175, r.timers["ticky"].val)
 }
 
 func TestRootScopeWithoutPrefix(t *testing.T) {

--- a/stats_test.go
+++ b/stats_test.go
@@ -50,7 +50,7 @@ func (r *statsTestReporter) Capabilities() Capabilities {
 func (r *statsTestReporter) Flush() {}
 
 func TestCounter(t *testing.T) {
-	counter := newCounter()
+	counter := newCounter(nil)
 	r := &statsTestReporter{}
 
 	counter.Inc(1)
@@ -67,7 +67,7 @@ func TestCounter(t *testing.T) {
 }
 
 func TestGauge(t *testing.T) {
-	gauge := newGauge()
+	gauge := newGauge(nil)
 	r := &statsTestReporter{}
 
 	gauge.Update(42)
@@ -82,7 +82,7 @@ func TestGauge(t *testing.T) {
 
 func TestTimer(t *testing.T) {
 	r := &statsTestReporter{}
-	timer := newTimer("t1", nil, r)
+	timer := newTimer("t1", nil, r, nil)
 
 	timer.Record(42 * time.Millisecond)
 	assert.Equal(t, 42*time.Millisecond, r.last)


### PR DESCRIPTION
This PR adds a new method `NewCachedRootScope` and a new
`CachedReporter` interface.

This `CachedReporter` interface allows for onetime allocation
of counters, gauges & timers. This allows for the CachedReporter
to cached the tags map and do pre-computation.

The actual runtime interface after all the scopes & metrics are
allocated at startup just involves `ReportCount(int64)` and friends.

This enables a reporter backend to implement a more involved BUT
more performant interface.

I've got a benchmark using an internal reporter where I was measuring the
overhead of adding 3 timers to a HTTP server.

 - master, 3 tally.Timers per request ~= 27% cpu overhead & 50 allocs per timer
 - this branch, 3 tally.Timers per request ~= 11% cpu overhead & 25 allocs per timer

This is a 2x improvement and allows us to have more timers in our
applications.

r: @robskillington @martin-mao
cc: @Matt-Esch @zhenghuiwang