### PR TITLE
[Support Messagepack Encoding - PART 1] Refactor M3 reporter to support multiple encodings

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: cdbc433d199ac0d184d56f461f87cb93db4f60658218f85a2b39c4614e4c1c68
-updated: 2017-02-05T22:15:53.246370902-05:00
+updated: 2017-02-11T16:30:12.270530306-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -16,7 +16,7 @@ imports:
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/protobuf
-  version: 2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8
+  version: 3852dcfda249c2097355a6aabb199a28d97b30df
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -33,13 +33,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 6d76b79f239843a04e8ad8dfd8fcadfa3920236f
+  version: dd2f054febf4a6c00f2343686efb775948a8bff4
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 testImports:

--- a/m3/config_test.go
+++ b/m3/config_test.go
@@ -38,7 +38,7 @@ func TestConfigSimple(t *testing.T) {
 	r, err := c.NewReporter()
 	require.NoError(t, err)
 
-	reporter := r.(*reporter)
+	reporter := r.(*thriftReporter)
 	_, ok := reporter.client.Transport.(*thriftudp.TUDPTransport)
 	assert.True(t, ok)
 	assert.True(t, tagEquals(reporter.commonTags, "service", "my-service"))
@@ -54,7 +54,7 @@ func TestConfigMulti(t *testing.T) {
 	r, err := c.NewReporter()
 	require.NoError(t, err)
 
-	reporter := r.(*reporter)
+	reporter := r.(*thriftReporter)
 	_, ok := reporter.client.Transport.(*thriftudp.TMultiUDPTransport)
 	assert.True(t, ok)
 	assert.True(t, tagEquals(reporter.commonTags, "service", "my-service"))

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -28,7 +28,7 @@ import (
 	"github.com/uber-go/tally"
 )
 
-// Encoding describes what format metrics should be encoded when sent over the wire.
+// Encoding describes what format metrics should be encoded in when sent over the wire.
 type Encoding int
 
 // The M3 reporter supports both Thrift and Messagepack encoding. Undeclared is the default

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -22,29 +22,21 @@ package m3
 
 import (
 	"errors"
-	"fmt"
 	"io"
-	"math"
-	"os"
-	"sync"
 	"time"
 
 	"github.com/uber-go/tally"
-	"github.com/uber-go/tally/m3/customtransports"
-	m3thrift "github.com/uber-go/tally/m3/thrift"
-	"github.com/uber-go/tally/m3/thriftudp"
-
-	"github.com/apache/thrift/lib/go/thrift"
 )
 
-// Protocol describes a M3 thrift transport protocol.
-type Protocol int
+// Encoding describes what format metrics should be encoded when sent over the wire.
+type Encoding int
 
-// Compact and Binary represent the compact and
-// binary thrift protocols respectively.
+// The M3 reporter supports both Thrift and Messagepack encoding. Undeclared is the default
+// encoding in an Options struct.
 const (
-	Compact Protocol = iota
-	Binary
+	Undeclared Encoding = iota
+	Thrift
+	Messagepack
 )
 
 const (
@@ -58,32 +50,10 @@ const (
 	DefaultMaxQueueSize = 4096
 	// DefaultMaxPacketSize is the default M3 reporter max packet size.
 	DefaultMaxPacketSize = int32(1440)
-
-	emitMetricBatchOverhead = 19
-)
-
-// Initialize max vars in init function to avoid lint error.
-var (
-	maxInt64   int64
-	maxFloat64 float64
-)
-
-func init() {
-	maxInt64 = math.MaxInt64
-	maxFloat64 = math.MaxFloat64
-}
-
-type metricType int
-
-const (
-	counterType metricType = iota + 1
-	timerType
-	gaugeType
 )
 
 var (
-	errNoHostPorts   = errors.New("at least one entry for HostPorts is required")
-	errCommonTagSize = errors.New("common tags serialized size exceeds packet size")
+	errNoHostPorts = errors.New("at least one entry for HostPorts is required")
 )
 
 // Reporter is an M3 reporter.
@@ -92,27 +62,9 @@ type Reporter interface {
 	io.Closer
 }
 
-// reporter is a metrics backend that reports metrics to a local or
-// remote M3 collector, metrics are batched together and emitted
-// via either thrift compact or binary protocol in batch UDP packets.
-type reporter struct {
-	client       *m3thrift.M3Client
-	curBatch     *m3thrift.MetricBatch
-	curBatchLock sync.Mutex
-	calc         *customtransport.TCalcTransport
-	calcProto    thrift.TProtocol
-	calcLock     sync.Mutex
-	commonTags   map[*m3thrift.MetricTag]bool
-	freeBytes    int32
-	processors   sync.WaitGroup
-	resourcePool *resourcePool
-	closeChan    chan struct{}
-
-	metCh chan sizedMetric
-}
-
 // Options is a set of options for the M3 reporter.
 type Options struct {
+	Encoding           Encoding
 	HostPorts          []string
 	Service            string
 	Env                string
@@ -133,313 +85,9 @@ func NewReporter(opts Options) (Reporter, error) {
 		opts.MaxPacketSizeBytes = DefaultMaxPacketSize
 	}
 
-	// Create M3 thrift client
-	var trans thrift.TTransport
-	var err error
-	if len(opts.HostPorts) == 0 {
-		err = errNoHostPorts
-	} else if len(opts.HostPorts) == 1 {
-		trans, err = thriftudp.NewTUDPClientTransport(opts.HostPorts[0], "")
-	} else {
-		trans, err = thriftudp.NewTMultiUDPClientTransport(opts.HostPorts, "")
-	}
-	if err != nil {
-		return nil, err
+	if opts.Encoding == Undeclared || opts.Encoding == Thrift {
+		return newThriftReporter(opts)
 	}
 
-	var protocolFactory thrift.TProtocolFactory
-	if opts.Protocol == Compact {
-		protocolFactory = thrift.NewTCompactProtocolFactory()
-	} else {
-		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
-	}
-
-	client := m3thrift.NewM3ClientFactory(trans, protocolFactory)
-	resourcePool := newResourcePool(protocolFactory)
-
-	// Create common tags
-	tags := resourcePool.getTagList()
-	for k, v := range opts.CommonTags {
-		tags[createTag(resourcePool, k, v)] = true
-	}
-	if opts.CommonTags[ServiceTag] == "" {
-		if opts.Service == "" {
-			return nil, fmt.Errorf("%s common tag is required", ServiceTag)
-		}
-		tags[createTag(resourcePool, ServiceTag, opts.Service)] = true
-	}
-	if opts.CommonTags[EnvTag] == "" {
-		if opts.Env == "" {
-			return nil, fmt.Errorf("%s common tag is required", EnvTag)
-		}
-		tags[createTag(resourcePool, EnvTag, opts.Env)] = true
-	}
-	if opts.IncludeHost {
-		if opts.CommonTags[HostTag] == "" {
-			hostname, err := os.Hostname()
-			if err != nil {
-				return nil, fmt.Errorf("error resolving host tag: %v", err)
-			}
-			tags[createTag(resourcePool, HostTag, hostname)] = true
-		}
-	}
-
-	// Calculate size of common tags
-	batch := resourcePool.getBatch()
-	batch.CommonTags = tags
-	batch.Metrics = []*m3thrift.Metric{}
-	proto := resourcePool.getProto()
-	batch.Write(proto)
-	calc := proto.Transport().(*customtransport.TCalcTransport)
-	numOverheadBytes := emitMetricBatchOverhead + calc.GetCount()
-	calc.ResetCount()
-
-	freeBytes := opts.MaxPacketSizeBytes - numOverheadBytes
-	if freeBytes <= 0 {
-		return nil, errCommonTagSize
-	}
-
-	r := &reporter{
-		client:       client,
-		curBatch:     batch,
-		calc:         calc,
-		calcProto:    proto,
-		commonTags:   tags,
-		freeBytes:    freeBytes,
-		resourcePool: resourcePool,
-		metCh:        make(chan sizedMetric, opts.MaxQueueSize),
-	}
-
-	r.processors.Add(1)
-	go r.process()
-
-	return r, nil
-}
-
-// AllocateCounter implements tally.CachedStatsReporter.
-func (r *reporter) AllocateCounter(
-	name string, tags map[string]string,
-) tally.CachedCount {
-	counter := r.newMetric(name, tags, counterType)
-	size := r.calculateSize(counter)
-	return cachedMetric{counter, r, size}
-}
-
-// AllocateGauge implements tally.CachedStatsReporter.
-func (r *reporter) AllocateGauge(
-	name string, tags map[string]string,
-) tally.CachedGauge {
-	gauge := r.newMetric(name, tags, gaugeType)
-	size := r.calculateSize(gauge)
-	return cachedMetric{gauge, r, size}
-}
-
-// AllocateTimer implements tally.CachedStatsReporter.
-func (r *reporter) AllocateTimer(
-	name string, tags map[string]string,
-) tally.CachedTimer {
-	timer := r.newMetric(name, tags, timerType)
-	size := r.calculateSize(timer)
-	return cachedMetric{timer, r, size}
-}
-
-func (r *reporter) newMetric(
-	name string,
-	tags map[string]string,
-	t metricType,
-) *m3thrift.Metric {
-	var (
-		m      = r.resourcePool.getMetric()
-		metVal = r.resourcePool.getValue()
-	)
-	m.Name = name
-	if tags != nil {
-		metTags := r.resourcePool.getTagList()
-		for k, v := range tags {
-			val := v
-			metTag := r.resourcePool.getTag()
-			metTag.TagName = k
-			metTag.TagValue = &val
-			metTags[metTag] = true
-		}
-		m.Tags = metTags
-	}
-	m.Timestamp = &maxInt64
-
-	switch t {
-	case counterType:
-		c := r.resourcePool.getCount()
-		c.I64Value = &maxInt64
-		metVal.Count = c
-	case gaugeType:
-		g := r.resourcePool.getGauge()
-		g.DValue = &maxFloat64
-		metVal.Gauge = g
-	case timerType:
-		t := r.resourcePool.getTimer()
-		t.I64Value = &maxInt64
-		metVal.Timer = t
-	}
-	m.MetricValue = metVal
-
-	return m
-}
-
-func (r *reporter) calculateSize(m *m3thrift.Metric) int32 {
-	r.calcLock.Lock()
-	m.Write(r.calcProto)
-	size := r.calc.GetCount()
-	r.calc.ResetCount()
-	r.calcLock.Unlock()
-	return size
-}
-
-func (r *reporter) reportCopyMetric(
-	m *m3thrift.Metric,
-	size int32,
-	t metricType,
-	iValue int64,
-	dValue float64,
-) {
-	copy := r.resourcePool.getMetric()
-	copy.Name = m.Name
-	copy.Tags = m.Tags
-	timestampNano := time.Now().UnixNano()
-	copy.Timestamp = &timestampNano
-	copy.MetricValue = r.resourcePool.getValue()
-
-	switch t {
-	case counterType:
-		c := r.resourcePool.getCount()
-		c.I64Value = &iValue
-		copy.MetricValue.Count = c
-	case gaugeType:
-		g := r.resourcePool.getGauge()
-		g.DValue = &dValue
-		copy.MetricValue.Gauge = g
-	case timerType:
-		t := r.resourcePool.getTimer()
-		t.I64Value = &iValue
-		copy.MetricValue.Timer = t
-	}
-
-	select {
-	case r.metCh <- sizedMetric{copy, size}:
-	default:
-	}
-}
-
-// Flush implements tally.CachedStatsReporter.
-func (r *reporter) Flush() {
-	r.metCh <- sizedMetric{}
-}
-
-// Close waits for metrics to be flushed before closing the backend.
-func (r *reporter) Close() (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("close error occurred: %v", r)
-		}
-	}()
-
-	close(r.metCh)
-	r.processors.Wait()
-	return
-}
-
-func (r *reporter) Capabilities() tally.Capabilities {
-	return r
-}
-
-func (r *reporter) Reporting() bool {
-	return true
-}
-
-func (r *reporter) Tagging() bool {
-	return true
-}
-
-func (r *reporter) process() {
-	mets := make([]*m3thrift.Metric, 0, (r.freeBytes / 10))
-	bytes := int32(0)
-
-	for smet := range r.metCh {
-		if smet.m == nil {
-			// Explicit flush requested
-			if len(mets) > 0 {
-				mets = r.flush(mets)
-				bytes = 0
-			}
-			continue
-		}
-
-		if bytes+smet.size > r.freeBytes {
-			mets = r.flush(mets)
-			bytes = 0
-		}
-
-		mets = append(mets, smet.m)
-		bytes += smet.size
-	}
-
-	if len(mets) > 0 {
-		// Final flush
-		r.flush(mets)
-	}
-
-	r.processors.Done()
-}
-
-func (r *reporter) flush(
-	mets []*m3thrift.Metric,
-) []*m3thrift.Metric {
-	r.curBatchLock.Lock()
-	r.curBatch.Metrics = mets
-	r.client.EmitMetricBatch(r.curBatch)
-	r.curBatch.Metrics = nil
-	r.curBatchLock.Unlock()
-
-	r.resourcePool.releaseShallowMetrics(mets)
-
-	for i := range mets {
-		mets[i] = nil
-	}
-	return mets[:0]
-}
-
-func createTag(
-	pool *resourcePool,
-	tagName, tagValue string,
-) *m3thrift.MetricTag {
-	tag := pool.getTag()
-	tag.TagName = tagName
-	if tagValue != "" {
-		tag.TagValue = &tagValue
-	}
-
-	return tag
-}
-
-type cachedMetric struct {
-	metric   *m3thrift.Metric
-	reporter *reporter
-	size     int32
-}
-
-func (c cachedMetric) ReportCount(value int64) {
-	c.reporter.reportCopyMetric(c.metric, c.size, counterType, value, 0)
-}
-
-func (c cachedMetric) ReportGauge(value float64) {
-	c.reporter.reportCopyMetric(c.metric, c.size, gaugeType, 0, value)
-}
-
-func (c cachedMetric) ReportTimer(interval time.Duration) {
-	val := int64(interval)
-	c.reporter.reportCopyMetric(c.metric, c.size, timerType, val, 0)
-}
-
-type sizedMetric struct {
-	m    *m3thrift.Metric
-	size int32
+	return nil, nil
 }

--- a/m3/reporter_benchmark_test.go
+++ b/m3/reporter_benchmark_test.go
@@ -39,7 +39,7 @@ const (
 func BenchmarkNewMetric(b *testing.B) {
 	protocolFactory := thrift.NewTCompactProtocolFactory()
 	resourcePool := newResourcePool(protocolFactory)
-	benchReporter := &reporter{resourcePool: resourcePool}
+	benchReporter := &thriftReporter{resourcePool: resourcePool}
 
 	for n := 0; n < b.N; n++ {
 		benchReporter.newMetric("foo", nil, counterType)
@@ -49,7 +49,7 @@ func BenchmarkNewMetric(b *testing.B) {
 func BenchmarkCalulateSize(b *testing.B) {
 	protocolFactory := thrift.NewTCompactProtocolFactory()
 	resourcePool := newResourcePool(protocolFactory)
-	benchReporter := &reporter{resourcePool: resourcePool}
+	benchReporter := &thriftReporter{resourcePool: resourcePool}
 
 	val := int64(123456)
 	met := benchReporter.newMetric("foo", nil, counterType)

--- a/m3/reporter_test.go
+++ b/m3/reporter_test.go
@@ -167,7 +167,7 @@ func TestMultiReporter(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Close()
 
-	reporter, ok := r.(*reporter)
+	reporter, ok := r.(*thriftReporter)
 	require.True(t, ok)
 	multitransport, ok := reporter.client.Transport.(*thriftudp.TMultiUDPTransport)
 	require.NotNil(t, multitransport)
@@ -308,7 +308,7 @@ func TestReporterSpecifyService(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Close()
 
-	reporter, ok := r.(*reporter)
+	reporter, ok := r.(*thriftReporter)
 	require.True(t, ok)
 	assert.Equal(t, 3, len(reporter.commonTags))
 	for tag := range reporter.commonTags {
@@ -338,7 +338,7 @@ func TestIncludeHost(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer r.Close()
-	withoutHost, ok := r.(*reporter)
+	withoutHost, ok := r.(*thriftReporter)
 	require.True(t, ok)
 	assert.False(t, tagIncluded(withoutHost.commonTags, "host"))
 
@@ -350,7 +350,7 @@ func TestIncludeHost(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer r.Close()
-	withHost, ok := r.(*reporter)
+	withHost, ok := r.(*thriftReporter)
 	require.True(t, ok)
 	assert.True(t, tagIncluded(withHost.commonTags, "host"))
 }

--- a/m3/resource_pool_test.go
+++ b/m3/resource_pool_test.go
@@ -39,7 +39,7 @@ func TestM3ResourcePoolMetric(t *testing.T) {
 	cv := p.getCount()
 	cmv.Count = cv
 	cv.I64Value = &v
-	cm.Tags = map[*m3thrift.MetricTag]bool{createTag(p, "t1", "v1"): true}
+	cm.Tags = map[*m3thrift.MetricTag]bool{createThriftTag(p, "t1", "v1"): true}
 
 	gm := p.getMetric()
 	gmv := p.getValue()

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -61,7 +61,7 @@ func newTestReporterScope(
 		// Ensure reporter is closed too
 		var open, readStatus bool
 		select {
-		case _, open = <-r.(*reporter).metCh:
+		case _, open = <-r.(*thriftReporter).metCh:
 			readStatus = true
 		default:
 		}

--- a/m3/thrift_reporter.go
+++ b/m3/thrift_reporter.go
@@ -1,0 +1,406 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber-go/tally/m3/customtransports"
+	m3thrift "github.com/uber-go/tally/m3/thrift"
+	"github.com/uber-go/tally/m3/thriftudp"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// Protocol describes a M3 thrift transport protocol.
+type Protocol int
+
+// Compact and Binary represent the compact and
+// binary thrift protocols respectively.
+const (
+	Compact Protocol = iota
+	Binary
+)
+
+const (
+	emitMetricBatchOverhead = 19
+)
+
+// Initialize max vars in init function to avoid lint error.
+var (
+	maxInt64   int64
+	maxFloat64 float64
+)
+
+func init() {
+	maxInt64 = math.MaxInt64
+	maxFloat64 = math.MaxFloat64
+}
+
+type metricType int
+
+const (
+	counterType metricType = iota + 1
+	timerType
+	gaugeType
+)
+
+var (
+	errCommonTagSize = errors.New("common tags serialized size exceeds packet size")
+)
+
+// reporter is a metrics backend that reports metrics to a local or
+// remote M3 collector, metrics are batched together and emitted
+// via either thrift compact or binary protocol in batch UDP packets.
+type thriftReporter struct {
+	client       *m3thrift.M3Client
+	curBatch     *m3thrift.MetricBatch
+	curBatchLock sync.Mutex
+	calc         *customtransport.TCalcTransport
+	calcProto    thrift.TProtocol
+	calcLock     sync.Mutex
+	commonTags   map[*m3thrift.MetricTag]bool
+	freeBytes    int32
+	processors   sync.WaitGroup
+	resourcePool *resourcePool
+	closeChan    chan struct{}
+
+	metCh chan sizedMetric
+}
+
+// newThriftReporter creates a new M3 reporter which emits metrics using a Thrift encoding.
+func newThriftReporter(opts Options) (Reporter, error) {
+	// Create M3 thrift client
+	var trans thrift.TTransport
+	var err error
+	if len(opts.HostPorts) == 0 {
+		err = errNoHostPorts
+	} else if len(opts.HostPorts) == 1 {
+		trans, err = thriftudp.NewTUDPClientTransport(opts.HostPorts[0], "")
+	} else {
+		trans, err = thriftudp.NewTMultiUDPClientTransport(opts.HostPorts, "")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var protocolFactory thrift.TProtocolFactory
+	if opts.Protocol == Compact {
+		protocolFactory = thrift.NewTCompactProtocolFactory()
+	} else {
+		protocolFactory = thrift.NewTBinaryProtocolFactoryDefault()
+	}
+
+	client := m3thrift.NewM3ClientFactory(trans, protocolFactory)
+	resourcePool := newResourcePool(protocolFactory)
+
+	// Create common tags
+	tags := resourcePool.getTagList()
+	for k, v := range opts.CommonTags {
+		tags[createTag(resourcePool, k, v)] = true
+	}
+	if opts.CommonTags[ServiceTag] == "" {
+		if opts.Service == "" {
+			return nil, fmt.Errorf("%s common tag is required", ServiceTag)
+		}
+		tags[createTag(resourcePool, ServiceTag, opts.Service)] = true
+	}
+	if opts.CommonTags[EnvTag] == "" {
+		if opts.Env == "" {
+			return nil, fmt.Errorf("%s common tag is required", EnvTag)
+		}
+		tags[createTag(resourcePool, EnvTag, opts.Env)] = true
+	}
+	if opts.IncludeHost {
+		if opts.CommonTags[HostTag] == "" {
+			hostname, err := os.Hostname()
+			if err != nil {
+				return nil, fmt.Errorf("error resolving host tag: %v", err)
+			}
+			tags[createTag(resourcePool, HostTag, hostname)] = true
+		}
+	}
+
+	// Calculate size of common tags
+	batch := resourcePool.getBatch()
+	batch.CommonTags = tags
+	batch.Metrics = []*m3thrift.Metric{}
+	proto := resourcePool.getProto()
+	batch.Write(proto)
+	calc := proto.Transport().(*customtransport.TCalcTransport)
+	numOverheadBytes := emitMetricBatchOverhead + calc.GetCount()
+	calc.ResetCount()
+
+	freeBytes := opts.MaxPacketSizeBytes - numOverheadBytes
+	if freeBytes <= 0 {
+		return nil, errCommonTagSize
+	}
+
+	r := &thriftReporter{
+		client:       client,
+		curBatch:     batch,
+		calc:         calc,
+		calcProto:    proto,
+		commonTags:   tags,
+		freeBytes:    freeBytes,
+		resourcePool: resourcePool,
+		metCh:        make(chan sizedMetric, opts.MaxQueueSize),
+	}
+
+	r.processors.Add(1)
+	go r.process()
+
+	return r, nil
+}
+
+// AllocateCounter implements tally.CachedStatsReporter.
+func (r *thriftReporter) AllocateCounter(
+	name string, tags map[string]string,
+) tally.CachedCount {
+	counter := r.newMetric(name, tags, counterType)
+	size := r.calculateSize(counter)
+	return cachedMetric{counter, r, size}
+}
+
+// AllocateGauge implements tally.CachedStatsReporter.
+func (r *thriftReporter) AllocateGauge(
+	name string, tags map[string]string,
+) tally.CachedGauge {
+	gauge := r.newMetric(name, tags, gaugeType)
+	size := r.calculateSize(gauge)
+	return cachedMetric{gauge, r, size}
+}
+
+// AllocateTimer implements tally.CachedStatsReporter.
+func (r *thriftReporter) AllocateTimer(
+	name string, tags map[string]string,
+) tally.CachedTimer {
+	timer := r.newMetric(name, tags, timerType)
+	size := r.calculateSize(timer)
+	return cachedMetric{timer, r, size}
+}
+
+func (r *thriftReporter) newMetric(
+	name string,
+	tags map[string]string,
+	t metricType,
+) *m3thrift.Metric {
+	var (
+		m      = r.resourcePool.getMetric()
+		metVal = r.resourcePool.getValue()
+	)
+	m.Name = name
+	if tags != nil {
+		metTags := r.resourcePool.getTagList()
+		for k, v := range tags {
+			val := v
+			metTag := r.resourcePool.getTag()
+			metTag.TagName = k
+			metTag.TagValue = &val
+			metTags[metTag] = true
+		}
+		m.Tags = metTags
+	}
+	m.Timestamp = &maxInt64
+
+	switch t {
+	case counterType:
+		c := r.resourcePool.getCount()
+		c.I64Value = &maxInt64
+		metVal.Count = c
+	case gaugeType:
+		g := r.resourcePool.getGauge()
+		g.DValue = &maxFloat64
+		metVal.Gauge = g
+	case timerType:
+		t := r.resourcePool.getTimer()
+		t.I64Value = &maxInt64
+		metVal.Timer = t
+	}
+	m.MetricValue = metVal
+
+	return m
+}
+
+func (r *thriftReporter) calculateSize(m *m3thrift.Metric) int32 {
+	r.calcLock.Lock()
+	m.Write(r.calcProto)
+	size := r.calc.GetCount()
+	r.calc.ResetCount()
+	r.calcLock.Unlock()
+	return size
+}
+
+func (r *thriftReporter) reportCopyMetric(
+	m *m3thrift.Metric,
+	size int32,
+	t metricType,
+	iValue int64,
+	dValue float64,
+) {
+	copy := r.resourcePool.getMetric()
+	copy.Name = m.Name
+	copy.Tags = m.Tags
+	timestampNano := time.Now().UnixNano()
+	copy.Timestamp = &timestampNano
+	copy.MetricValue = r.resourcePool.getValue()
+
+	switch t {
+	case counterType:
+		c := r.resourcePool.getCount()
+		c.I64Value = &iValue
+		copy.MetricValue.Count = c
+	case gaugeType:
+		g := r.resourcePool.getGauge()
+		g.DValue = &dValue
+		copy.MetricValue.Gauge = g
+	case timerType:
+		t := r.resourcePool.getTimer()
+		t.I64Value = &iValue
+		copy.MetricValue.Timer = t
+	}
+
+	select {
+	case r.metCh <- sizedMetric{copy, size}:
+	default:
+	}
+}
+
+// Flush implements tally.CachedStatsReporter.
+func (r *thriftReporter) Flush() {
+	r.metCh <- sizedMetric{}
+}
+
+// Close waits for metrics to be flushed before closing the backend.
+func (r *thriftReporter) Close() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("close error occurred: %v", r)
+		}
+	}()
+
+	close(r.metCh)
+	r.processors.Wait()
+	return
+}
+
+func (r *thriftReporter) Capabilities() tally.Capabilities {
+	return r
+}
+
+func (r *thriftReporter) Reporting() bool {
+	return true
+}
+
+func (r *thriftReporter) Tagging() bool {
+	return true
+}
+
+func (r *thriftReporter) process() {
+	mets := make([]*m3thrift.Metric, 0, (r.freeBytes / 10))
+	bytes := int32(0)
+
+	for smet := range r.metCh {
+		if smet.m == nil {
+			// Explicit flush requested
+			if len(mets) > 0 {
+				mets = r.flush(mets)
+				bytes = 0
+			}
+			continue
+		}
+
+		if bytes+smet.size > r.freeBytes {
+			mets = r.flush(mets)
+			bytes = 0
+		}
+
+		mets = append(mets, smet.m)
+		bytes += smet.size
+	}
+
+	if len(mets) > 0 {
+		// Final flush
+		r.flush(mets)
+	}
+
+	r.processors.Done()
+}
+
+func (r *thriftReporter) flush(
+	mets []*m3thrift.Metric,
+) []*m3thrift.Metric {
+	r.curBatchLock.Lock()
+	r.curBatch.Metrics = mets
+	r.client.EmitMetricBatch(r.curBatch)
+	r.curBatch.Metrics = nil
+	r.curBatchLock.Unlock()
+
+	r.resourcePool.releaseShallowMetrics(mets)
+
+	for i := range mets {
+		mets[i] = nil
+	}
+	return mets[:0]
+}
+
+func createTag(
+	pool *resourcePool,
+	tagName, tagValue string,
+) *m3thrift.MetricTag {
+	tag := pool.getTag()
+	tag.TagName = tagName
+	if tagValue != "" {
+		tag.TagValue = &tagValue
+	}
+
+	return tag
+}
+
+type cachedMetric struct {
+	metric   *m3thrift.Metric
+	reporter *thriftReporter
+	size     int32
+}
+
+func (c cachedMetric) ReportCount(value int64) {
+	c.reporter.reportCopyMetric(c.metric, c.size, counterType, value, 0)
+}
+
+func (c cachedMetric) ReportGauge(value float64) {
+	c.reporter.reportCopyMetric(c.metric, c.size, gaugeType, 0, value)
+}
+
+func (c cachedMetric) ReportTimer(interval time.Duration) {
+	val := int64(interval)
+	c.reporter.reportCopyMetric(c.metric, c.size, timerType, val, 0)
+}
+
+type sizedMetric struct {
+	m    *m3thrift.Metric
+	size int32
+}


### PR DESCRIPTION
Recent work has shown that encoding metrics using Messagepack may be more efficient than using Thrift. Consequently, I'd like to introduce a new M3 reporter which sends metrics over the wire using Messagepack instead of Thrift. This first PR refactors the current M3 reporter code to make it easier to add a Messagepack reporter. Subsequent PR's will introduce the actual Messagepack reporter.