### PR TITLE
Add zero allocation Stopwatch for both timer and histograms

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -181,11 +181,11 @@ func (t *timer) Record(interval time.Duration) {
 }
 
 func (t *timer) Start() Stopwatch {
-	return Stopwatch{Start: globalClock.Now(), Recorder: t}
+	return NewStopwatch(globalClock.Now(), t)
 }
 
-func (t *timer) RecordStopwatch(sw Stopwatch) {
-	d := globalClock.Now().Sub(sw.Start)
+func (t *timer) RecordStopwatch(stopwatchStart time.Time) {
+	d := globalClock.Now().Sub(stopwatchStart)
 	t.Record(d)
 }
 
@@ -367,11 +367,11 @@ func (h *histogram) RecordDuration(value time.Duration) {
 }
 
 func (h *histogram) Start() Stopwatch {
-	return Stopwatch{Start: globalClock.Now(), Recorder: h}
+	return NewStopwatch(globalClock.Now(), h)
 }
 
-func (h *histogram) RecordStopwatch(sw Stopwatch) {
-	d := globalClock.Now().Sub(sw.Start)
+func (h *histogram) RecordStopwatch(stopwatchStart time.Time) {
+	d := globalClock.Now().Sub(stopwatchStart)
 	h.RecordDuration(d)
 }
 

--- a/stats.go
+++ b/stats.go
@@ -172,16 +172,21 @@ func newTimer(
 	return t
 }
 
-func (t *timer) Start() Stopwatch {
-	return timerStopwatch{start: globalClock.Now(), timer: t}
-}
-
 func (t *timer) Record(interval time.Duration) {
 	if t.cachedTimer != nil {
 		t.cachedTimer.ReportTimer(interval)
 	} else {
 		t.reporter.ReportTimer(t.name, t.tags, interval)
 	}
+}
+
+func (t *timer) Start() Stopwatch {
+	return Stopwatch{Start: globalClock.Now(), Recorder: t}
+}
+
+func (t *timer) RecordStopwatch(sw Stopwatch) {
+	d := globalClock.Now().Sub(sw.Start)
+	t.Record(d)
 }
 
 func (t *timer) snapshot() []time.Duration {
@@ -192,19 +197,6 @@ func (t *timer) snapshot() []time.Duration {
 	}
 	t.unreported.RUnlock()
 	return snap
-}
-
-type timerStopwatch struct {
-	start   time.Time
-	timer   *timer
-	stopped int32
-}
-
-func (s timerStopwatch) Stop() {
-	if atomic.CompareAndSwapInt32(&s.stopped, 0, 1) {
-		d := globalClock.Now().Sub(s.start)
-		s.timer.Record(d)
-	}
 }
 
 type timerNoReporterSink struct {
@@ -375,7 +367,12 @@ func (h *histogram) RecordDuration(value time.Duration) {
 }
 
 func (h *histogram) Start() Stopwatch {
-	return histogramStopwatch{start: globalClock.Now(), histogram: h}
+	return Stopwatch{Start: globalClock.Now(), Recorder: h}
+}
+
+func (h *histogram) RecordStopwatch(sw Stopwatch) {
+	d := globalClock.Now().Sub(sw.Start)
+	h.RecordDuration(d)
 }
 
 type histogramBucket struct {
@@ -413,19 +410,6 @@ func newHistogramBucket(
 		)
 	}
 	return bucket
-}
-
-type histogramStopwatch struct {
-	start     time.Time
-	histogram *histogram
-	stopped   int32
-}
-
-func (s histogramStopwatch) Stop() {
-	if atomic.CompareAndSwapInt32(&s.stopped, 0, 1) {
-		d := globalClock.Now().Sub(s.start)
-		s.histogram.RecordDuration(d)
-	}
 }
 
 // NullStatsReporter is an implementation of StatsReporter than simply does nothing.

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -20,7 +20,10 @@
 
 package tally
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func BenchmarkCounterInc(b *testing.B) {
 	c := &counter{}
@@ -66,7 +69,7 @@ func BenchmarkReportGaugeWithData(b *testing.B) {
 	}
 }
 
-func BenchmarkTimerInterval(b *testing.B) {
+func BenchmarkTimerStopwatch(b *testing.B) {
 	t := &timer{
 		name:     "bencher",
 		tags:     nil,
@@ -84,6 +87,7 @@ func BenchmarkTimerReport(b *testing.B) {
 		reporter: NullStatsReporter,
 	}
 	for n := 0; n < b.N; n++ {
-		t.Record(1234)
+		start := time.Now()
+		t.Record(time.Since(start))
 	}
 }

--- a/types.go
+++ b/types.go
@@ -99,19 +99,25 @@ type Histogram interface {
 // Stop() method to report time elapsed since its created back to the
 // timer or histogram.
 type Stopwatch struct {
-	Start    time.Time
-	Recorder StopwatchRecorder
+	start    time.Time
+	recorder StopwatchRecorder
+}
+
+// NewStopwatch creates a new immutable stopwatch for recording the start
+// time to a stopwatch reporter.
+func NewStopwatch(start time.Time, r StopwatchRecorder) Stopwatch {
+	return Stopwatch{start: start, recorder: r}
 }
 
 // Stop reports time elapsed since the stopwatch start to the recorder.
 func (sw Stopwatch) Stop() {
-	sw.Recorder.RecordStopwatch(sw)
+	sw.recorder.RecordStopwatch(sw.start)
 }
 
 // StopwatchRecorder is a recorder that is called when a stopwatch is
 // stopped with Stop().
 type StopwatchRecorder interface {
-	RecordStopwatch(sw Stopwatch)
+	RecordStopwatch(stopwatchStart time.Time)
 }
 
 // Buckets is an interface that can represent a set of buckets

--- a/types.go
+++ b/types.go
@@ -95,10 +95,23 @@ type Histogram interface {
 	Start() Stopwatch
 }
 
-// Stopwatch is a helper for simpler tracking of elapsed time.
-type Stopwatch interface {
-	// Stop records the difference between the current clock and start time.
-	Stop()
+// Stopwatch is a helper for simpler tracking of elapsed time, use the
+// Stop() method to report time elapsed since its created back to the
+// timer or histogram.
+type Stopwatch struct {
+	Start    time.Time
+	Recorder StopwatchRecorder
+}
+
+// Stop reports time elapsed since the stopwatch start to the recorder.
+func (sw Stopwatch) Stop() {
+	sw.Recorder.RecordStopwatch(sw)
+}
+
+// StopwatchRecorder is a recorder that is called when a stopwatch is
+// stopped with Stop().
+type StopwatchRecorder interface {
+	RecordStopwatch(sw Stopwatch)
 }
 
 // Buckets is an interface that can represent a set of buckets


### PR DESCRIPTION
It's still a little slower than the default `start := time.Now(); timer.Record(time.Since(start))` but it doesn't cause any allocations any longer.

```
$ go test -v -run none -bench BenchmarkTimerStopwatch -benchmem
BenchmarkTimerStopwatch-4       30000000                51.3 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/uber-go/tally        1.726s

$ go test -v -run none -bench BenchmarkTimerReport -benchmem
BenchmarkTimerReport-4          50000000                36.5 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/uber-go/tally        2.005s
```

cc @xichen2020 @akshayjshah @Raynos 