### PR TITLE
Fix possible flush after close semantics for scope

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -66,7 +66,7 @@ type scope struct {
 	defaultBuckets Buckets
 
 	registry *scopeRegistry
-	status   *scopeStatus
+	status   scopeStatus
 
 	cm sync.RWMutex
 	gm sync.RWMutex
@@ -153,7 +153,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 		registry: &scopeRegistry{
 			subscopes: make(map[string]*scope),
 		},
-		status: &scopeStatus{
+		status: scopeStatus{
 			closed: false,
 			quit:   make(chan struct{}, 1),
 		},


### PR DESCRIPTION
There was the possibility a reporter might have `Flush` or any of the other report methods called on it after it had been closed itself.  This change fixes that possibility by holding a status lock during each report loop run.

cc @xichen2020