### PR TITLE
Use a unique ID for metrics returned from Snapshot

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -503,7 +503,7 @@ func (s *scope) uniqueID(name string, tags map[string]string) string {
 		l += len(k) + len(v)
 	}
 
-	// Size of the buffer include separator bytes
+	// Size of the buffer includes separator bytes
 	buf := bytes.NewBuffer(make([]byte, 0, l+2*len(tags)+1))
 	buf.WriteString(name)
 	buf.WriteString(componentSeparator)

--- a/scope.go
+++ b/scope.go
@@ -38,9 +38,9 @@ var (
 	DefaultSeparator = "."
 	// ComponentSeparator is the separator used to separate a metric's name and it's tags in its ID
 	ComponentSeparator = "+"
-	// TagPairSeparator is the separator used to separate pairs of tags
+	// TagPairSeparator is the separator used to separate pairs of tags in metric's ID
 	TagPairSeparator = ","
-	// TagValueSeparator is the separator used to separate a tags key and value
+	// TagValueSeparator is the separator used to separate a tag's key and value in a metric's ID
 	TagValueSeparator = "="
 
 	globalClock = clock.New()

--- a/scope.go
+++ b/scope.go
@@ -504,7 +504,7 @@ func (s *scope) uniqueID(name string, tags map[string]string) string {
 	}
 
 	// Size of the buffer includes separator bytes
-	buf := bytes.NewBuffer(make([]byte, 0, l+2*len(tags)+1))
+	buf := bytes.NewBuffer(make([]byte, 0, l+2*len(tags)))
 	buf.WriteString(name)
 	buf.WriteString(componentSeparator)
 

--- a/scope_test.go
+++ b/scope_test.go
@@ -566,23 +566,23 @@ func TestSnapshot(t *testing.T) {
 	counters, gauges, timers :=
 		snap.Counters(), snap.Gauges(), snap.Timers()
 
-	assert.EqualValues(t, 1, counters["foo.beep"].Value())
-	assert.EqualValues(t, commonTags, counters["foo.beep"].Tags())
+	assert.EqualValues(t, 1, counters["foo.beep+env=test"].Value())
+	assert.EqualValues(t, commonTags, counters["foo.beep+env=test"].Tags())
 
-	assert.EqualValues(t, 2, gauges["foo.bzzt"].Value())
-	assert.EqualValues(t, commonTags, gauges["foo.bzzt"].Tags())
+	assert.EqualValues(t, 2, gauges["foo.bzzt+env=test"].Value())
+	assert.EqualValues(t, commonTags, gauges["foo.bzzt+env=test"].Tags())
 
 	assert.EqualValues(t, []time.Duration{
 		1 * time.Second,
 		2 * time.Second,
-	}, timers["foo.brrr"].Values())
-	assert.EqualValues(t, commonTags, timers["foo.brrr"].Tags())
+	}, timers["foo.brrr+env=test"].Values())
+	assert.EqualValues(t, commonTags, timers["foo.brrr+env=test"].Tags())
 
-	assert.EqualValues(t, 1, counters["foo.boop"].Value())
+	assert.EqualValues(t, 1, counters["foo.boop+env=test,service=test"].Value())
 	assert.EqualValues(t, map[string]string{
 		"env":     "test",
 		"service": "test",
-	}, counters["foo.boop"].Tags())
+	}, counters["foo.boop+env=test,service=test"].Tags())
 }
 
 func TestCapabilities(t *testing.T) {


### PR DESCRIPTION
This PR addresses #34 by introducing a new function `uniqueID` which will create a unique ID for a metric using it fully qualified name and tags. This ID is then used as the key for the maps created `Snapshot` so that metrics with the same fully qualified names but different tags will not overwrite one another.