### PR TITLE
Add histogram support to Snapshot

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -565,10 +565,10 @@ type HistogramSnapshot interface {
 	// Tags returns the tags
 	Tags() map[string]string
 
-	// Values returns the sample values for a valueHistogram
+	// Values returns the sample values by upper bound for a valueHistogram
 	Values() map[float64]int64
 
-	// Durations returns the sample values for a durationHistogram
+	// Durations returns the sample values by upper bound for a durationHistogram
 	Durations() map[time.Duration]int64
 }
 

--- a/scope.go
+++ b/scope.go
@@ -516,7 +516,7 @@ type Snapshot interface {
 	// Timers returns a snapshot of timer values since last report execution
 	Timers() map[string]TimerSnapshot
 
-	// Histograms returns a snapshot of histogram buckets since last report execution
+	// Histograms returns a snapshot of histogram samples since last report execution
 	Histograms() map[string]HistogramSnapshot
 }
 
@@ -564,10 +564,10 @@ type HistogramSnapshot interface {
 	// Tags returns the tags
 	Tags() map[string]string
 
-	// Values returns the counts for a valueHistogram
+	// Values returns the sample values for a valueHistogram
 	Values() map[float64]int64
 
-	// Durations returns the counts for a durationHistogram
+	// Durations returns the sample values for a durationHistogram
 	Durations() map[time.Duration]int64
 }
 

--- a/scope.go
+++ b/scope.go
@@ -462,7 +462,8 @@ func (s *scope) Snapshot() Snapshot {
 		ss.hm.RLock()
 		for key, h := range ss.histograms {
 			name := ss.fullyQualifiedName(key)
-			snap.histograms[name] = &histogramSnapshot{
+			id := KeyForPrefixedStringMap(name, tags)
+			snap.histograms[id] = &histogramSnapshot{
 				name:      name,
 				tags:      tags,
 				values:    h.snapshotValues(),

--- a/scope_test.go
+++ b/scope_test.go
@@ -21,6 +21,7 @@
 package tally
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -560,11 +561,14 @@ func TestSnapshot(t *testing.T) {
 	s.Gauge("bzzt").Update(2)
 	s.Timer("brrr").Record(1 * time.Second)
 	s.Timer("brrr").Record(2 * time.Second)
+	s.Histogram("fizz", ValueBuckets{0, 2, 4}).RecordValue(1)
+	s.Histogram("fizz", ValueBuckets{0, 2, 4}).RecordValue(5)
+	s.Histogram("buzz", DurationBuckets{time.Second * 2, time.Second * 4}).RecordDuration(time.Second)
 	child.Counter("boop").Inc(1)
 
 	snap := s.Snapshot()
-	counters, gauges, timers :=
-		snap.Counters(), snap.Gauges(), snap.Timers()
+	counters, gauges, timers, histograms :=
+		snap.Counters(), snap.Gauges(), snap.Timers(), snap.Histograms()
 
 	assert.EqualValues(t, 1, counters["foo.beep+env=test"].Value())
 	assert.EqualValues(t, commonTags, counters["foo.beep+env=test"].Tags())
@@ -578,7 +582,25 @@ func TestSnapshot(t *testing.T) {
 	}, timers["foo.brrr+env=test"].Values())
 	assert.EqualValues(t, commonTags, timers["foo.brrr+env=test"].Tags())
 
-	assert.EqualValues(t, 1, counters["foo.boop+env=test,service=test"].Value())
+	assert.EqualValues(t, map[float64]int64{
+		0:               0,
+		2:               1,
+		4:               0,
+		math.MaxFloat64: 1,
+	}, histograms["foo.fizz"].Values())
+	assert.EqualValues(t, map[time.Duration]int64(nil), histograms["foo.fizz"].Durations())
+	assert.EqualValues(t, commonTags, histograms["foo.fizz"].Tags())
+
+	assert.EqualValues(t, map[float64]int64(nil), histograms["foo.buzz"].Values())
+	assert.EqualValues(t, map[time.Duration]int64{
+		0:               0,
+		time.Second * 2: 1,
+		time.Second * 4: 0,
+		math.MaxInt64:   0,
+	}, histograms["foo.buzz"].Durations())
+	assert.EqualValues(t, commonTags, histograms["foo.buzz"].Tags())
+
+	assert.EqualValues(t, 1, counters["foo.boop"].Value())
 	assert.EqualValues(t, map[string]string{
 		"env":     "test",
 		"service": "test",

--- a/scope_test.go
+++ b/scope_test.go
@@ -587,20 +587,20 @@ func TestSnapshot(t *testing.T) {
 		2:               1,
 		4:               0,
 		math.MaxFloat64: 1,
-	}, histograms["foo.fizz"].Values())
-	assert.EqualValues(t, map[time.Duration]int64(nil), histograms["foo.fizz"].Durations())
-	assert.EqualValues(t, commonTags, histograms["foo.fizz"].Tags())
+	}, histograms["foo.fizz+env=test"].Values())
+	assert.EqualValues(t, map[time.Duration]int64(nil), histograms["foo.fizz+env=test"].Durations())
+	assert.EqualValues(t, commonTags, histograms["foo.fizz+env=test"].Tags())
 
-	assert.EqualValues(t, map[float64]int64(nil), histograms["foo.buzz"].Values())
+	assert.EqualValues(t, map[float64]int64(nil), histograms["foo.buzz+env=test"].Values())
 	assert.EqualValues(t, map[time.Duration]int64{
 		0:               0,
 		time.Second * 2: 1,
 		time.Second * 4: 0,
 		math.MaxInt64:   0,
-	}, histograms["foo.buzz"].Durations())
-	assert.EqualValues(t, commonTags, histograms["foo.buzz"].Tags())
+	}, histograms["foo.buzz+env=test"].Durations())
+	assert.EqualValues(t, commonTags, histograms["foo.buzz+env=test"].Tags())
 
-	assert.EqualValues(t, 1, counters["foo.boop"].Value())
+	assert.EqualValues(t, 1, counters["foo.boop+env=test,service=test"].Value())
 	assert.EqualValues(t, map[string]string{
 		"env":     "test",
 		"service": "test",

--- a/stats.go
+++ b/stats.go
@@ -375,6 +375,32 @@ func (h *histogram) RecordStopwatch(stopwatchStart time.Time) {
 	h.RecordDuration(d)
 }
 
+func (h *histogram) snapshotValues() map[float64]int64 {
+	if h.htype == durationHistogramType {
+		return nil
+	}
+
+	vals := make(map[float64]int64, len(h.buckets))
+	for i := range h.buckets {
+		vals[h.buckets[i].valueUpperBound] = h.buckets[i].samples.value()
+	}
+
+	return vals
+}
+
+func (h *histogram) snapshotDurations() map[time.Duration]int64 {
+	if h.htype == valueHistogramType {
+		return nil
+	}
+
+	durations := make(map[time.Duration]int64, len(h.buckets))
+	for i := range h.buckets {
+		durations[h.buckets[i].durationUpperBound] = h.buckets[i].samples.value()
+	}
+
+	return durations
+}
+
 type histogramBucket struct {
 	h                    *histogram
 	samples              *counter


### PR DESCRIPTION
As noted in #37, currently `Snapshot` doesn't capture histograms. Consequently, this PR adds histogram support to `Snapshot`.