### PR TITLE
Add HTTP endpoint to view metric snapshots

### DIFF
--- a/http/encoder.go
+++ b/http/encoder.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 import (

--- a/http/encoder.go
+++ b/http/encoder.go
@@ -1,0 +1,359 @@
+package http
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+const (
+	counterType   = "counter"
+	gaugeType     = "gauge"
+	timerType     = "timer"
+	histogramType = "histogram"
+)
+
+var (
+	encPool = newEncoderPool(64, 32, 32, 32)
+)
+
+type encoderPool struct {
+	stringsPool *tally.ObjectPool
+	floatsPool  *tally.ObjectPool
+	intsPool    *tally.ObjectPool
+}
+
+// Encoder encodes a tally Snapshot and writes it to an underlying io.Writer
+type Encoder interface {
+	Encode(s tally.Snapshot) error
+}
+
+type encoder struct {
+	w io.Writer
+}
+
+// NewEncoder returns a new Encoder which encodes a metrics snapshot to an io.Writer in a text
+// format similiar to the one used by Prometheus.
+func NewEncoder(w io.Writer) Encoder {
+	return &encoder{w: w}
+}
+
+func (e *encoder) Encode(s tally.Snapshot) error {
+	_, err := e.encode(s)
+	return err
+}
+
+func (e *encoder) encode(s tally.Snapshot) (int, error) {
+	var written int
+
+	for _, counter := range s.Counters() {
+		n, err := e.encodeCounter(counter)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+
+	for _, gauge := range s.Gauges() {
+		n, err := e.encodeGauge(gauge)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+
+	for _, timer := range s.Timers() {
+		n, err := e.encodeTimer(timer)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+
+	for _, histogram := range s.Histograms() {
+		n, err := e.encodeHistogram(histogram)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+func (e *encoder) encodeComments(meta tally.Metadata, metricType string) (int, error) {
+	var written int
+
+	// TODO(jeromefroe): Add an optional description to metrics and encode it here when present to
+	// match the Prometheus 'HELP' comments.
+
+	n, err := fmt.Fprintf(e.w, "# TYPE %s %s\n", meta.Name(), metricType)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	return written, nil
+}
+
+func (e *encoder) encodeNameAndTags(meta tally.Metadata, lastTagName, lastTagValue string) (int, error) {
+	var written int
+
+	n, err := fmt.Fprint(e.w, meta.Name())
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	tags := meta.Tags()
+
+	keys := encPool.stringsPool.Get().([]string)
+	defer encPool.releaseStrings(keys)
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	separator := '{'
+	tagFormat := `%c%s="%s"`
+	for _, k := range keys {
+		// NB(jeromefroe): We follow the Prometheus approach here and only escape tag values as they
+		// are more likely to be defined elsewhere in a program and accidentally contain control
+		// characters in. In the future, if we ever perform validation on tags we can remove this.
+		v := escapeString(tags[k])
+		n, err := fmt.Fprintf(e.w, tagFormat, separator, k, v)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		separator = ','
+	}
+
+	if lastTagName != "" {
+		n, err := fmt.Fprintf(e.w, tagFormat, separator, lastTagName, escapeString(lastTagValue))
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+
+	n, err = e.w.Write([]byte{'}'})
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	return written, nil
+}
+
+func (e *encoder) encodeCounter(counter tally.CounterSnapshot) (int, error) {
+	var written int
+
+	n, err := e.encodeComments(counter, counterType)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = e.encodeNameAndTags(counter, "", "")
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = fmt.Fprintf(e.w, " %v\n", counter.Value())
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	return written, nil
+}
+
+func (e *encoder) encodeGauge(gauge tally.GaugeSnapshot) (int, error) {
+	var written int
+
+	n, err := e.encodeComments(gauge, gaugeType)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = e.encodeNameAndTags(gauge, "", "")
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = fmt.Fprintf(e.w, " %v\n", gauge.Value())
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	return written, nil
+}
+
+func (e *encoder) encodeTimer(timer tally.TimerSnapshot) (int, error) {
+	var written int
+
+	n, err := e.encodeComments(timer, timerType)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = e.encodeNameAndTags(timer, "", "")
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = fmt.Fprintf(e.w, " %v\n", timer.Values())
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	return written, nil
+}
+
+func (e *encoder) encodeHistogram(histogram tally.HistogramSnapshot) (int, error) {
+	var written int
+	maxUpperBoundStr := "+Inf"
+
+	n, err := e.encodeComments(histogram, histogramType)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	values := histogram.Values()
+
+	if len(values) > 0 {
+		valueUpperBounds := encPool.floatsPool.Get().([]float64)
+		defer encPool.releaseFloats(valueUpperBounds)
+
+		for ub := range values {
+			valueUpperBounds = append(valueUpperBounds, ub)
+		}
+		sort.Float64s(valueUpperBounds)
+
+		for _, upperBound := range valueUpperBounds {
+			var upperBoundStr string
+			if upperBound == math.MaxFloat64 {
+				upperBoundStr = maxUpperBoundStr
+			} else {
+				upperBoundStr = fmt.Sprint(upperBound)
+			}
+
+			n, err = e.encodeNameAndTags(histogram, "le", upperBoundStr)
+			written += n
+			if err != nil {
+				return written, err
+			}
+
+			count := values[upperBound]
+
+			n, err = fmt.Fprintf(e.w, " %v\n", count)
+			written += n
+			if err != nil {
+				return written, err
+			}
+		}
+	}
+
+	durations := histogram.Durations()
+
+	if len(durations) > 0 {
+		durationUpperBounds := encPool.intsPool.Get().([]int)
+		defer encPool.releaseInts(durationUpperBounds)
+
+		for ub := range durations {
+			durationUpperBounds = append(durationUpperBounds, int(ub))
+		}
+		sort.Ints(durationUpperBounds)
+
+		for _, upperBound := range durationUpperBounds {
+			var upperBoundStr string
+			if upperBound == math.MaxInt64 {
+				upperBoundStr = maxUpperBoundStr
+			} else {
+				upperBoundStr = fmt.Sprint(time.Duration(upperBound))
+			}
+
+			n, err = e.encodeNameAndTags(histogram, "le", upperBoundStr)
+			written += n
+			if err != nil {
+				return written, err
+			}
+
+			count := durations[time.Duration(upperBound)]
+
+			n, err = fmt.Fprintf(e.w, " %v\n", count)
+			written += n
+			if err != nil {
+				return written, err
+			}
+		}
+	}
+
+	return written, nil
+}
+
+var (
+	escaper = strings.NewReplacer("\\", `\\`, "\n", `\n`, "\"", `\"`)
+)
+
+// escapeString replaces a backslash with '\\', a new line with '\n', and a double quote with '\"'.
+func escapeString(s string) string {
+	return escaper.Replace(s)
+}
+
+func newEncoderPool(size, slen, flen, ilen int) *encoderPool {
+	s := tally.NewObjectPool(size)
+	s.Init(func() interface{} {
+		return make([]string, 0, slen)
+	})
+
+	f := tally.NewObjectPool(size)
+	f.Init(func() interface{} {
+		return make([]float64, 0, flen)
+	})
+
+	i := tally.NewObjectPool(size)
+	i.Init(func() interface{} {
+		return make([]int, 0, ilen)
+	})
+
+	return &encoderPool{
+		stringsPool: s,
+		floatsPool:  f,
+		intsPool:    i,
+	}
+}
+
+func (p *encoderPool) releaseStrings(strs []string) {
+	for i := range strs {
+		strs[i] = ""
+	}
+	p.stringsPool.Put(strs[:0])
+}
+
+func (p *encoderPool) releaseFloats(floats []float64) {
+	for i := range floats {
+		floats[i] = 0
+	}
+	p.floatsPool.Put(floats[:0])
+}
+
+func (p *encoderPool) releaseInts(ints []int) {
+	for i := range ints {
+		ints[i] = 0
+	}
+	p.intsPool.Put(ints[:0])
+}

--- a/http/encoder_test.go
+++ b/http/encoder_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 import (

--- a/http/encoder_test.go
+++ b/http/encoder_test.go
@@ -1,0 +1,328 @@
+package http
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+)
+
+type mockMetadata struct {
+	mockName func() string
+	mockTags func() map[string]string
+}
+
+func (m *mockMetadata) Name() string {
+	if m.mockName != nil {
+		return m.mockName()
+	}
+
+	return ""
+}
+
+func (m *mockMetadata) Tags() map[string]string {
+	if m.mockTags != nil {
+		return m.mockTags()
+	}
+
+	return nil
+}
+
+var metadata = &mockMetadata{
+	mockName: func() string { return "requests" },
+	mockTags: func() map[string]string {
+		return map[string]string{"status_code": "200", "request_type": "GET"}
+	},
+}
+
+func TestEncodeComment(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	metricTypes := []string{counterType, gaugeType, timerType, histogramType}
+	for _, metricType := range metricTypes {
+		n, err := e.encodeComments(metadata, metricType)
+		actual := buf.String()
+		expected := "# TYPE requests " + metricType + "\n"
+		assert.Nil(t, err)
+		assert.Equal(t, n, len(expected))
+		assert.Equal(t, expected, actual)
+
+		buf.Reset()
+	}
+}
+
+func TestEncodeNameAndTags(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encodeNameAndTags(metadata, "", "")
+	actual := buf.String()
+	expected := `requests{request_type="GET",status_code="200"}`
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+
+	buf.Reset()
+
+	n, err = e.encodeNameAndTags(metadata, "quantile", "75")
+	actual = buf.String()
+	expected = `requests{request_type="GET",status_code="200",quantile="75"}`
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+}
+
+type mockCounterSnapshot struct {
+	*mockMetadata
+	mockValue func() int64
+}
+
+func (m *mockCounterSnapshot) Value() int64 {
+	if m.mockValue != nil {
+		return m.mockValue()
+	}
+
+	return -1
+}
+
+var counterSnapshot = &mockCounterSnapshot{
+	mockMetadata: metadata,
+	mockValue:    func() int64 { return 42 },
+}
+
+func TestEncodeCounter(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encodeCounter(counterSnapshot)
+	actual := buf.String()
+	expected := "# TYPE requests counter\n" +
+		`requests{request_type="GET",status_code="200"} 42` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+}
+
+type mockGaugeSnapshot struct {
+	*mockMetadata
+	mockValue func() float64
+}
+
+func (m *mockGaugeSnapshot) Value() float64 {
+	if m.mockValue != nil {
+		return m.mockValue()
+	}
+
+	return -1
+}
+
+var gaugeSnapshot = &mockGaugeSnapshot{
+	mockMetadata: metadata,
+	mockValue:    func() float64 { return 21.5 },
+}
+
+func TestEncodeGauge(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encodeGauge(gaugeSnapshot)
+	actual := buf.String()
+	expected := "# TYPE requests gauge\n" +
+		`requests{request_type="GET",status_code="200"} 21.5` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+}
+
+type mockTimerSnapshot struct {
+	*mockMetadata
+	mockValues func() []time.Duration
+}
+
+func (m *mockTimerSnapshot) Values() []time.Duration {
+	if m.mockValues != nil {
+		return m.mockValues()
+	}
+
+	return nil
+}
+
+var timerSnapshot = &mockTimerSnapshot{
+	mockMetadata: metadata,
+	mockValues: func() []time.Duration {
+		return []time.Duration{time.Second, time.Minute, 5 * time.Second}
+	},
+}
+
+func TestEncodeTimer(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encodeTimer(timerSnapshot)
+	actual := buf.String()
+	expected := "# TYPE requests timer\n" +
+		`requests{request_type="GET",status_code="200"} [1s 1m0s 5s]` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+}
+
+type mockHistogramSnapshot struct {
+	*mockMetadata
+	mockValues    func() map[float64]int64
+	mockDurations func() map[time.Duration]int64
+}
+
+func (m *mockHistogramSnapshot) Values() map[float64]int64 {
+	if m.mockValues != nil {
+		return m.mockValues()
+	}
+
+	return nil
+}
+
+func (m *mockHistogramSnapshot) Durations() map[time.Duration]int64 {
+	if m.mockDurations != nil {
+		return m.mockDurations()
+	}
+
+	return nil
+}
+
+var valuesHistogramSnapshot = &mockHistogramSnapshot{
+	mockMetadata: metadata,
+	mockValues: func() map[float64]int64 {
+		return map[float64]int64{
+			0:               0,
+			2:               1,
+			4:               0,
+			math.MaxFloat64: 1,
+		}
+	},
+}
+
+var durationsHistogramSnapshot = &mockHistogramSnapshot{
+	mockMetadata: metadata,
+	mockDurations: func() map[time.Duration]int64 {
+		return map[time.Duration]int64{
+			0:               0,
+			time.Second * 2: 1,
+			time.Second * 4: 0,
+			math.MaxInt64:   1,
+		}
+	},
+}
+
+func TestEncodeHistogram(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encodeHistogram(valuesHistogramSnapshot)
+	actual := buf.String()
+	expected := "# TYPE requests histogram\n" +
+		`requests{request_type="GET",status_code="200",le="0"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="2"} 1` + "\n" +
+		`requests{request_type="GET",status_code="200",le="4"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="+Inf"} 1` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+
+	buf.Reset()
+
+	n, err = e.encodeHistogram(durationsHistogramSnapshot)
+	actual = buf.String()
+	expected = "# TYPE requests histogram\n" +
+		`requests{request_type="GET",status_code="200",le="0s"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="2s"} 1` + "\n" +
+		`requests{request_type="GET",status_code="200",le="4s"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="+Inf"} 1` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+}
+
+type mockSnapshot struct {
+	mockCounters   func() map[string]tally.CounterSnapshot
+	mockGauges     func() map[string]tally.GaugeSnapshot
+	mockTimers     func() map[string]tally.TimerSnapshot
+	mockHistograms func() map[string]tally.HistogramSnapshot
+}
+
+func (m *mockSnapshot) Counters() map[string]tally.CounterSnapshot {
+	if m.mockCounters != nil {
+		return m.mockCounters()
+	}
+
+	return nil
+}
+
+func (m *mockSnapshot) Gauges() map[string]tally.GaugeSnapshot {
+	if m.mockGauges != nil {
+		return m.mockGauges()
+	}
+
+	return nil
+}
+
+func (m *mockSnapshot) Timers() map[string]tally.TimerSnapshot {
+	if m.mockTimers != nil {
+		return m.mockTimers()
+	}
+
+	return nil
+}
+
+func (m *mockSnapshot) Histograms() map[string]tally.HistogramSnapshot {
+	if m.mockHistograms != nil {
+		return m.mockHistograms()
+	}
+
+	return nil
+}
+
+var (
+	id       = tally.KeyForPrefixedStringMap(metadata.Name(), metadata.Tags())
+	snapshot = &mockSnapshot{
+		mockCounters: func() map[string]tally.CounterSnapshot {
+			return map[string]tally.CounterSnapshot{id: counterSnapshot}
+		},
+		mockGauges: func() map[string]tally.GaugeSnapshot {
+			return map[string]tally.GaugeSnapshot{id: gaugeSnapshot}
+		},
+		mockTimers: func() map[string]tally.TimerSnapshot {
+			return map[string]tally.TimerSnapshot{id: timerSnapshot}
+		},
+		mockHistograms: func() map[string]tally.HistogramSnapshot {
+			return map[string]tally.HistogramSnapshot{id: valuesHistogramSnapshot}
+		},
+	}
+)
+
+func TestEncode(t *testing.T) {
+	var buf bytes.Buffer
+	e := &encoder{w: &buf}
+
+	n, err := e.encode(snapshot)
+	actual := buf.String()
+	expected := "# TYPE requests counter\n" +
+		`requests{request_type="GET",status_code="200"} 42` + "\n" +
+		"# TYPE requests gauge\n" +
+		`requests{request_type="GET",status_code="200"} 21.5` + "\n" +
+		"# TYPE requests timer\n" +
+		`requests{request_type="GET",status_code="200"} [1s 1m0s 5s]` + "\n" +
+		"# TYPE requests histogram\n" +
+		`requests{request_type="GET",status_code="200",le="0"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="2"} 1` + "\n" +
+		`requests{request_type="GET",status_code="200",le="4"} 0` + "\n" +
+		`requests{request_type="GET",status_code="200",le="+Inf"} 1` + "\n"
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(expected))
+	assert.Equal(t, expected, actual)
+
+	buf.Reset()
+}

--- a/http/encoder_test.go
+++ b/http/encoder_test.go
@@ -229,7 +229,7 @@ var durationsHistogramSnapshot = &mockHistogramSnapshot{
 	mockMetadata: metadata,
 	mockDurations: func() map[time.Duration]int64 {
 		return map[time.Duration]int64{
-			0:               0,
+			time.Second * 0: 0,
 			time.Second * 2: 1,
 			time.Second * 4: 0,
 			math.MaxInt64:   1,

--- a/http/http.go
+++ b/http/http.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 import (

--- a/http/http.go
+++ b/http/http.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/uber-go/tally"
+)
+
+// NB(jeromefroe): We follow the model of Prometheus here and define different Content-Type
+// values in case we want to support other content types in the future.
+
+// Format specifies the HTTP content type of the different wire protocols.
+type Format string
+
+// Constants to assemble the Content-Type values for the different wire protocols.
+const (
+	TextVersion = "0.0.1"
+
+	// The Content-Type values for the different wire protocols.
+	TextFormat Format = `text/plain; version=` + TextVersion
+)
+
+const (
+	contentTypeHeader   = "Content-Type"
+	contentLengthHeader = "Content-Length"
+)
+
+var (
+	bufferPoolSize = 128
+	bufferPoolLen  = 8192
+	bufferPool     = tally.NewObjectPool(bufferPoolSize)
+)
+
+func init() {
+	bufferPool.Init(func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, bufferPoolLen))
+	})
+}
+
+func release(b *bytes.Buffer) {
+	b.Reset()
+	bufferPool.Put(b)
+}
+
+// Handler returns an http.Handler for the provided Scope.
+func Handler(s tally.Scope) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		snapshot := s.Snapshot()
+
+		buf := bufferPool.Get().(*bytes.Buffer)
+		defer release(buf)
+
+		enc := NewEncoder(buf)
+
+		if err := enc.Encode(snapshot); err != nil {
+			http.Error(w, "An error has occurred during metrics encoding:\n\n"+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		header := w.Header()
+		header.Set(contentTypeHeader, string(TextFormat))
+		header.Set(contentLengthHeader, fmt.Sprint(buf.Len()))
+		w.Write(buf.Bytes())
+	})
+}

--- a/http/http.go
+++ b/http/http.go
@@ -64,8 +64,8 @@ func release(b *bytes.Buffer) {
 	bufferPool.Put(b)
 }
 
-// Handler returns an http.Handler for the provided Scope.
-func Handler(s tally.Scope) http.Handler {
+// ScopeHandler returns an http.Handler for the provided Scope.
+func ScopeHandler(s tally.Scope) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		snapshot := s.Snapshot()
 

--- a/http/http.go
+++ b/http/http.go
@@ -64,8 +64,8 @@ func release(b *bytes.Buffer) {
 	bufferPool.Put(b)
 }
 
-// ScopeHandler returns an http.Handler for the provided Scope.
-func ScopeHandler(s tally.Scope) http.Handler {
+// Handler returns an http.Handler for the provided SnapshotScope.
+func Handler(s tally.SnapshotScope) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		snapshot := s.Snapshot()
 

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,0 +1,3 @@
+package http
+
+// TODO(jeromefroe): Finish writing tests for http package.

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -47,7 +47,7 @@ func TestHTTPHandler(t *testing.T) {
 	dh := s.Histogram("sew", tally.DurationBuckets{time.Second * 2, time.Second * 4})
 	dh.RecordDuration(time.Second)
 
-	handler := ScopeHandler(s)
+	handler := Handler(s)
 
 	writer := httptest.NewRecorder()
 	request, _ := http.NewRequest("GET", "/", nil)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 // TODO(jeromefroe): Finish writing tests for http package.

--- a/scope.go
+++ b/scope.go
@@ -105,7 +105,7 @@ type ScopeOptions struct {
 // NewRootScope creates a new root Scope with a set of options and
 // a reporting interval.
 // Must provide either a StatsReporter or a CachedStatsReporter.
-func NewRootScope(opts ScopeOptions, interval time.Duration) (Scope, io.Closer) {
+func NewRootScope(opts ScopeOptions, interval time.Duration) (SnapshotScope, io.Closer) {
 	s := newRootScope(opts, interval)
 	return s, s
 }
@@ -115,7 +115,7 @@ func NewRootScope(opts ScopeOptions, interval time.Duration) (Scope, io.Closer) 
 func NewTestScope(
 	prefix string,
 	tags map[string]string,
-) Scope {
+) SnapshotScope {
 	return newRootScope(ScopeOptions{Prefix: prefix, Tags: tags}, 0)
 }
 

--- a/scope.go
+++ b/scope.go
@@ -111,12 +111,11 @@ func NewRootScope(opts ScopeOptions, interval time.Duration) (Scope, io.Closer) 
 }
 
 // NewTestScope creates a new Scope without a stats reporter with the
-// given prefix and adds the ability to take snapshots of metrics emitted
-// to it.
+// given prefix.
 func NewTestScope(
 	prefix string,
 	tags map[string]string,
-) TestScope {
+) Scope {
 	return newRootScope(ScopeOptions{Prefix: prefix, Tags: tags}, 0)
 }
 
@@ -496,82 +495,6 @@ func (s *scope) fullyQualifiedName(name string) string {
 	return fmt.Sprintf("%s%s%s", s.prefix, s.separator, name)
 }
 
-// TestScope is a metrics collector that has no reporting, ensuring that
-// all emitted values have a given prefix or set of tags
-type TestScope interface {
-	Scope
-
-	// Snapshot returns a copy of all values since the last report execution,
-	// this is an expensive operation and should only be use for testing purposes
-	Snapshot() Snapshot
-}
-
-// Snapshot is a snapshot of values since last report execution
-type Snapshot interface {
-	// Counters returns a snapshot of all counter summations since last report execution
-	Counters() map[string]CounterSnapshot
-
-	// Gauges returns a snapshot of gauge last values since last report execution
-	Gauges() map[string]GaugeSnapshot
-
-	// Timers returns a snapshot of timer values since last report execution
-	Timers() map[string]TimerSnapshot
-
-	// Histograms returns a snapshot of histogram samples since last report execution
-	Histograms() map[string]HistogramSnapshot
-}
-
-// CounterSnapshot is a snapshot of a counter
-type CounterSnapshot interface {
-	// Name returns the name
-	Name() string
-
-	// Tags returns the tags
-	Tags() map[string]string
-
-	// Value returns the value
-	Value() int64
-}
-
-// GaugeSnapshot is a snapshot of a gauge
-type GaugeSnapshot interface {
-	// Name returns the name
-	Name() string
-
-	// Tags returns the tags
-	Tags() map[string]string
-
-	// Value returns the value
-	Value() float64
-}
-
-// TimerSnapshot is a snapshot of a timer
-type TimerSnapshot interface {
-	// Name returns the name
-	Name() string
-
-	// Tags returns the tags
-	Tags() map[string]string
-
-	// Values returns the values
-	Values() []time.Duration
-}
-
-// HistogramSnapshot is a snapshot of a histogram
-type HistogramSnapshot interface {
-	// Name returns the name
-	Name() string
-
-	// Tags returns the tags
-	Tags() map[string]string
-
-	// Values returns the sample values by upper bound for a valueHistogram
-	Values() map[float64]int64
-
-	// Durations returns the sample values by upper bound for a durationHistogram
-	Durations() map[time.Duration]int64
-}
-
 // mergeRightTags merges 2 sets of tags with the tags from tagsRight overriding values from tagsLeft
 func mergeRightTags(tagsLeft, tagsRight map[string]string) map[string]string {
 	if tagsLeft == nil && tagsRight == nil {
@@ -600,113 +523,4 @@ func copyStringMap(stringMap map[string]string) map[string]string {
 		result[k] = v
 	}
 	return result
-}
-
-type snapshot struct {
-	counters   map[string]CounterSnapshot
-	gauges     map[string]GaugeSnapshot
-	timers     map[string]TimerSnapshot
-	histograms map[string]HistogramSnapshot
-}
-
-func newSnapshot() *snapshot {
-	return &snapshot{
-		counters:   make(map[string]CounterSnapshot),
-		gauges:     make(map[string]GaugeSnapshot),
-		timers:     make(map[string]TimerSnapshot),
-		histograms: make(map[string]HistogramSnapshot),
-	}
-}
-
-func (s *snapshot) Counters() map[string]CounterSnapshot {
-	return s.counters
-}
-
-func (s *snapshot) Gauges() map[string]GaugeSnapshot {
-	return s.gauges
-}
-
-func (s *snapshot) Timers() map[string]TimerSnapshot {
-	return s.timers
-}
-
-func (s *snapshot) Histograms() map[string]HistogramSnapshot {
-	return s.histograms
-}
-
-type counterSnapshot struct {
-	name  string
-	tags  map[string]string
-	value int64
-}
-
-func (s *counterSnapshot) Name() string {
-	return s.name
-}
-
-func (s *counterSnapshot) Tags() map[string]string {
-	return s.tags
-}
-
-func (s *counterSnapshot) Value() int64 {
-	return s.value
-}
-
-type gaugeSnapshot struct {
-	name  string
-	tags  map[string]string
-	value float64
-}
-
-func (s *gaugeSnapshot) Name() string {
-	return s.name
-}
-
-func (s *gaugeSnapshot) Tags() map[string]string {
-	return s.tags
-}
-
-func (s *gaugeSnapshot) Value() float64 {
-	return s.value
-}
-
-type timerSnapshot struct {
-	name   string
-	tags   map[string]string
-	values []time.Duration
-}
-
-func (s *timerSnapshot) Name() string {
-	return s.name
-}
-
-func (s *timerSnapshot) Tags() map[string]string {
-	return s.tags
-}
-
-func (s *timerSnapshot) Values() []time.Duration {
-	return s.values
-}
-
-type histogramSnapshot struct {
-	name      string
-	tags      map[string]string
-	values    map[float64]int64
-	durations map[time.Duration]int64
-}
-
-func (s *histogramSnapshot) Name() string {
-	return s.name
-}
-
-func (s *histogramSnapshot) Tags() map[string]string {
-	return s.tags
-}
-
-func (s *histogramSnapshot) Values() map[float64]int64 {
-	return s.values
-}
-
-func (s *histogramSnapshot) Durations() map[time.Duration]int64 {
-	return s.durations
 }

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tally
 
 import "time"

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,112 @@
+package tally
+
+import "time"
+
+type snapshot struct {
+	counters   map[string]CounterSnapshot
+	gauges     map[string]GaugeSnapshot
+	timers     map[string]TimerSnapshot
+	histograms map[string]HistogramSnapshot
+}
+
+func newSnapshot() *snapshot {
+	return &snapshot{
+		counters:   make(map[string]CounterSnapshot),
+		gauges:     make(map[string]GaugeSnapshot),
+		timers:     make(map[string]TimerSnapshot),
+		histograms: make(map[string]HistogramSnapshot),
+	}
+}
+
+func (s *snapshot) Counters() map[string]CounterSnapshot {
+	return s.counters
+}
+
+func (s *snapshot) Gauges() map[string]GaugeSnapshot {
+	return s.gauges
+}
+
+func (s *snapshot) Timers() map[string]TimerSnapshot {
+	return s.timers
+}
+
+func (s *snapshot) Histograms() map[string]HistogramSnapshot {
+	return s.histograms
+}
+
+type counterSnapshot struct {
+	name  string
+	tags  map[string]string
+	value int64
+}
+
+func (s *counterSnapshot) Name() string {
+	return s.name
+}
+
+func (s *counterSnapshot) Tags() map[string]string {
+	return s.tags
+}
+
+func (s *counterSnapshot) Value() int64 {
+	return s.value
+}
+
+type gaugeSnapshot struct {
+	name  string
+	tags  map[string]string
+	value float64
+}
+
+func (s *gaugeSnapshot) Name() string {
+	return s.name
+}
+
+func (s *gaugeSnapshot) Tags() map[string]string {
+	return s.tags
+}
+
+func (s *gaugeSnapshot) Value() float64 {
+	return s.value
+}
+
+type timerSnapshot struct {
+	name   string
+	tags   map[string]string
+	values []time.Duration
+}
+
+func (s *timerSnapshot) Name() string {
+	return s.name
+}
+
+func (s *timerSnapshot) Tags() map[string]string {
+	return s.tags
+}
+
+func (s *timerSnapshot) Values() []time.Duration {
+	return s.values
+}
+
+type histogramSnapshot struct {
+	name      string
+	tags      map[string]string
+	values    map[float64]int64
+	durations map[time.Duration]int64
+}
+
+func (s *histogramSnapshot) Name() string {
+	return s.name
+}
+
+func (s *histogramSnapshot) Tags() map[string]string {
+	return s.tags
+}
+
+func (s *histogramSnapshot) Values() map[float64]int64 {
+	return s.values
+}
+
+func (s *histogramSnapshot) Durations() map[time.Duration]int64 {
+	return s.durations
+}

--- a/types.go
+++ b/types.go
@@ -57,6 +57,11 @@ type Scope interface {
 
 	// Capabilities returns a description of metrics reporting capabilities.
 	Capabilities() Capabilities
+
+	// Snapshot returns a copy of all values since the last report execution,
+	// this is an expensive operation and should only be used for testing or
+	// debugging purposes
+	Snapshot() Snapshot
 }
 
 // Counter is the interface for emitting counter type metrics.
@@ -149,4 +154,63 @@ type Capabilities interface {
 
 	// Tagging returns whether the reporter has the capability for tagged metrics.
 	Tagging() bool
+}
+
+// Snapshot is a snapshot of values since last report execution
+type Snapshot interface {
+	// Counters returns a snapshot of all counter summations since last report execution
+	Counters() map[string]CounterSnapshot
+
+	// Gauges returns a snapshot of gauge last values since last report execution
+	Gauges() map[string]GaugeSnapshot
+
+	// Timers returns a snapshot of timer values since last report execution
+	Timers() map[string]TimerSnapshot
+
+	// Histograms returns a snapshot of histogram samples since last report execution
+	Histograms() map[string]HistogramSnapshot
+}
+
+// Metadata returns the metadata for a metric
+type Metadata interface {
+	// Name returns the name of a metric
+	Name() string
+
+	// Tags returns the tags for a metric
+	Tags() map[string]string
+}
+
+// CounterSnapshot is a snapshot of a counter
+type CounterSnapshot interface {
+	Metadata
+
+	// Value returns the value
+	Value() int64
+}
+
+// GaugeSnapshot is a snapshot of a gauge
+type GaugeSnapshot interface {
+	Metadata
+
+	// Value returns the value
+	Value() float64
+}
+
+// TimerSnapshot is a snapshot of a timer
+type TimerSnapshot interface {
+	Metadata
+
+	// Values returns the values
+	Values() []time.Duration
+}
+
+// HistogramSnapshot is a snapshot of a histogram
+type HistogramSnapshot interface {
+	Metadata
+
+	// Values returns the sample values by upper bound for a valueHistogram
+	Values() map[float64]int64
+
+	// Durations returns the sample values by upper bound for a durationHistogram
+	Durations() map[time.Duration]int64
 }

--- a/types.go
+++ b/types.go
@@ -57,11 +57,6 @@ type Scope interface {
 
 	// Capabilities returns a description of metrics reporting capabilities.
 	Capabilities() Capabilities
-
-	// Snapshot returns a copy of all values since the last report execution,
-	// this is an expensive operation and should only be used for testing or
-	// debugging purposes
-	Snapshot() Snapshot
 }
 
 // Counter is the interface for emitting counter type metrics.
@@ -169,6 +164,16 @@ type Snapshot interface {
 
 	// Histograms returns a snapshot of histogram samples since last report execution
 	Histograms() map[string]HistogramSnapshot
+}
+
+// SnapshotScope is a Scope which can return a snapshot of currently queued metric
+type SnapshotScope interface {
+	Scope
+
+	// Snapshot returns a copy of all values since the last report execution,
+	// this is an expensive operation and should only be used for testing or
+	// debugging purposes
+	Snapshot() Snapshot
 }
 
 // Metadata returns the metadata for a metric


### PR DESCRIPTION
This PR adds the ability to get a HTTP handler for a Scope which users can use to add an endpoint to a HTTP server to view metric snapshots when debugging. It's not finished yet but I thought it might be helpful to put it up now to solicit feedback. I will update the PR when I finish the changes I want to make.