### PR TITLE
Fix licence link by inserting newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ BenchmarkTimerReport-8              	300000000	         5.69 ns/op
 ```
 
 <hr>
+
 Released under the [MIT License](LICENSE).
 
 [doc-img]: https://godoc.org/github.com/uber-go/tally?status.svg


### PR DESCRIPTION
Because of the inline HTML, GitHub wasn't parsing the markdown correctly.

Inserting a newline fixes this.