### PR TITLE
Skip appending '+' to metric keys without tags

### DIFF
--- a/key_gen.go
+++ b/key_gen.go
@@ -65,10 +65,13 @@ func KeyForPrefixedStringMap(
 
 	if prefix != nilString {
 		buf.WriteString(prefix)
-		buf.WriteByte(prefixSplitter)
 	}
 
 	sortedKeysLen := len(stringMap)
+	// don't write splitter if there are no tags to serialize
+	if sortedKeysLen > 0 {
+		buf.WriteByte(prefixSplitter)
+	}
 	for i := 0; i < sortedKeysLen; i++ {
 		buf.WriteString(keys[i])
 		buf.WriteByte(keyNameSplitter)

--- a/scope_test.go
+++ b/scope_test.go
@@ -607,6 +607,22 @@ func TestSnapshot(t *testing.T) {
 	}, counters["foo.boop+env=test,service=test"].Tags())
 }
 
+func TestSnapshot_NoTags(t *testing.T) {
+	s := NewTestScope("foo", nil)
+	s.Counter("bar").Inc(1)
+
+	snap := s.Snapshot()
+	assert.EqualValues(t, 1, snap.Counters()["foo.bar"].Value())
+
+	s.Tagged(map[string]string{"env": "test"}).Counter("fizz").Inc(1)
+	snap = s.Snapshot()
+	assert.EqualValues(t, 1, snap.Counters()["foo.fizz+env=test"].Value())
+
+	s.SubScope("baz").Counter("buzz").Inc(1)
+	snap = s.Snapshot()
+	assert.EqualValues(t, 1, snap.Counters()["foo.baz.buzz"].Value())
+}
+
 func TestCapabilities(t *testing.T) {
 	r := newTestStatsReporter()
 	s, closer := NewRootScope(ScopeOptions{Reporter: r}, 0)


### PR DESCRIPTION
The main use case for `TestScope` is for a user to emit metrics into it
and look up metrics in the snapshots of that scope via string keys to
ensure that their code behaves in some specific way as it pertains to
the emission of metrics.

If a user were to emit a counter named `"foo"` without any tags into a
`TestScope`, they would reasonably expect their metric to have name
`"foo"` in the snapshot of that scope. However due to the logic for
serializing tags we currently append the splitter `'+'` to that metric
regardless of whether or not there are any tags to serialize. For
example, the current behavior is:

```
s := tally.NewTestScope("foo", nil)
s.Counter("bar").Inc(1)
for k, v := range s.Snapshot().Counters() {
    fmt.Printf("'%s': %d\n", k, v.Value())
}

$ go run tally.go
'foo.bar+': 1
```

This changes the serialization logic to skip appending `'+'` if there
are no tags to serialize. While this change will modify the string keys
we use to store scopes in the registry, it should have no impact on
reporting of metrics as reporting we interact with the type-specific
metric maps directly as opposed to parsing the registry keys or
something similar. Thus this should only affect the use case for users
who were using test scopes without tags and expecting certain string
keys in the snapshots.

I recognize this is pretty picky so I'm happy to hear differing
opinions, but it feels wrong to keep appending `'+'` to string keys in
tests when there are no tags so I figured I'd put up a PR anyway :) .