### PR TITLE
Implement InstrumentedCall

### DIFF
--- a/instrument.go
+++ b/instrument.go
@@ -24,12 +24,19 @@ import (
 	"fmt"
 )
 
+const (
+	_resultType        = "result_type"
+	_resultTypeError   = "error"
+	_resultTypeSuccess = "success"
+	_timingFormat      = "%s.latency"
+)
+
 // NewInstrumentedCall returns an InstrumentedCall with the given name
 func NewInstrumentedCall(scope Scope, name string) InstrumentedCall {
 	return &instrumentedCall{
-		error:   scope.Tagged(map[string]string{"result_type": "error"}).Counter(name),
-		success: scope.Tagged(map[string]string{"result_type": "success"}).Counter(name),
-		timing:  scope.Timer(fmt.Sprintf("%s.latency", name)),
+		error:   scope.Tagged(map[string]string{_resultType: _resultTypeError}).Counter(name),
+		success: scope.Tagged(map[string]string{_resultType: _resultTypeSuccess}).Counter(name),
+		timing:  scope.Timer(fmt.Sprintf(_timingFormat, name)),
 	}
 }
 

--- a/instrument.go
+++ b/instrument.go
@@ -20,15 +20,11 @@
 
 package tally
 
-import (
-	"fmt"
-)
-
 const (
 	_resultType        = "result_type"
 	_resultTypeError   = "error"
 	_resultTypeSuccess = "success"
-	_timingFormat      = "%s.latency"
+	_timingFormat      = "latency"
 )
 
 // NewInstrumentedCall returns an InstrumentedCall with the given name
@@ -36,7 +32,7 @@ func NewInstrumentedCall(scope Scope, name string) InstrumentedCall {
 	return &instrumentedCall{
 		error:   scope.Tagged(map[string]string{_resultType: _resultTypeError}).Counter(name),
 		success: scope.Tagged(map[string]string{_resultType: _resultTypeSuccess}).Counter(name),
-		timing:  scope.Timer(fmt.Sprintf(_timingFormat, name)),
+		timing:  scope.SubScope(name).Timer(_timingFormat),
 	}
 }
 

--- a/instrument.go
+++ b/instrument.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tally
 
 import (

--- a/instrument.go
+++ b/instrument.go
@@ -1,0 +1,49 @@
+package tally
+
+import (
+	"fmt"
+)
+
+// NewInstrumentedCall returns an InstrumentedCall with the given name
+func NewInstrumentedCall(scope Scope, name string) InstrumentedCall {
+	return &instrumentedCall{
+		error:   scope.Tagged(map[string]string{"result_type": "error"}).Counter(name),
+		success: scope.Tagged(map[string]string{"result_type": "success"}).Counter(name),
+		timing:  scope.Timer(fmt.Sprintf("%s.latency", name)),
+	}
+}
+
+var defaultSuccessFilter = func(err error) bool {
+	return err == nil
+}
+
+type instrumentedCall struct {
+	scope   Scope
+	success Counter
+	error   Counter
+	timing  Timer
+}
+
+// Exec executes the given block of code, and records whether it succeeded or
+// failed, and the amount of time that it took
+func (call *instrumentedCall) Exec(f ExecFn) error {
+	return call.ExecWithFilter(f, defaultSuccessFilter)
+}
+
+// ExecWithFilter executes the given block of code, and records whether it succeeded or
+// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
+// to be actually success for server logic), and the amount of time that it took
+func (call *instrumentedCall) ExecWithFilter(f ExecFn, isSuccess SuccessFilter) error {
+	sw := call.timing.Start()
+
+	err := f()
+	if err != nil && !isSuccess(err) {
+		call.error.Inc(1.0)
+		return err
+	}
+
+	sw.Stop()
+	call.success.Inc(1.0)
+
+	return err
+}

--- a/instrument.go
+++ b/instrument.go
@@ -26,24 +26,24 @@ type instrumentedCall struct {
 
 // Exec executes the given block of code, and records whether it succeeded or
 // failed, and the amount of time that it took
-func (call *instrumentedCall) Exec(f ExecFn) error {
-	return call.ExecWithFilter(f, defaultSuccessFilter)
+func (c *instrumentedCall) Exec(f ExecFn) error {
+	return c.ExecWithFilter(f, defaultSuccessFilter)
 }
 
 // ExecWithFilter executes the given block of code, and records whether it succeeded or
 // failed based on the result of a custom filter (e.g. the filter could determine a bad request error
 // to be actually success for server logic), and the amount of time that it took
-func (call *instrumentedCall) ExecWithFilter(f ExecFn, isSuccess SuccessFilter) error {
-	sw := call.timing.Start()
+func (c *instrumentedCall) ExecWithFilter(f ExecFn, isSuccess SuccessFilterFn) error {
+	sw := c.timing.Start()
 
 	err := f()
 	if err != nil && !isSuccess(err) {
-		call.error.Inc(1.0)
+		c.error.Inc(1.0)
 		return err
 	}
 
 	sw.Stop()
-	call.success.Inc(1.0)
+	c.success.Inc(1.0)
 
 	return err
 }

--- a/scope.go
+++ b/scope.go
@@ -499,6 +499,16 @@ func (s *scope) Snapshot() Snapshot {
 	return snap
 }
 
+// InstrumentedCall returns an InstrumentedCall with the given name
+func (s *scope) InstrumentedCall(name string) InstrumentedCall {
+	return &instrumentedCall{
+		scope:       s,
+		errorName:   fmt.Sprintf("%s.errors", name),
+		successName: fmt.Sprintf("%s.success", name),
+		timingName:  fmt.Sprintf("%s.timing", name),
+	}
+}
+
 func (s *scope) Close() error {
 	s.status.Lock()
 
@@ -751,4 +761,49 @@ func (s *histogramSnapshot) Values() map[float64]int64 {
 
 func (s *histogramSnapshot) Durations() map[time.Duration]int64 {
 	return s.durations
+}
+
+var defaultSuccessFilter = func(err error) bool {
+	return err == nil
+}
+
+type instrumentedCall struct {
+	scope       Scope
+	successName string
+	errorName   string
+	timingName  string
+}
+
+// Exec executes the given block of code, and records whether it succeeded or
+// failed, and the amount of time that it took
+func (call *instrumentedCall) Exec(f func() error) error {
+	return call.ExecWithFilter(f, defaultSuccessFilter)
+}
+
+// ExecWithFilter executes the given block of code, and records whether it succeeded or
+// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
+// to be actually success for server logic), and the amount of time that it took
+func (call *instrumentedCall) ExecWithFilter(f func() error, isSuccess SuccessFilter) error {
+	sw := call.scope.Timer(call.timingName).Start()
+
+	err := f()
+	if err != nil && !isSuccess(err) {
+		call.scope.Counter(call.errorName).Inc(1.0)
+		return err
+	}
+
+	sw.Stop()
+	call.scope.Counter(call.successName).Inc(1.0)
+
+	return err
+}
+
+// Tagged returns a new InstrumentedCall with the given set of tags
+func (call *instrumentedCall) Tagged(tags map[string]string) InstrumentedCall {
+	return &instrumentedCall{
+		scope:       call.scope.Tagged(tags),
+		successName: call.successName,
+		errorName:   call.errorName,
+		timingName:  call.timingName,
+	}
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -321,16 +321,16 @@ func TestInstrumentedCallSuccess(t *testing.T) {
 
 	r.cg.Add(1)
 	r.tg.Add(1)
-	err := NewInstrumentedCall(s, "testInstrumented").Exec(func() error {
+	err := NewInstrumentedCall(s, "test_instrumented").Exec(func() error {
 		return nil
 	})
 	assert.Nil(t, err)
 
 	r.WaitAll()
-	assert.EqualValues(t, 1, r.counters["testInstrumented"].val)
-	resultType, _ := r.counters["testInstrumented"].tags["result_type"]
+	assert.EqualValues(t, 1, r.counters["test_instrumented"].val)
+	resultType, _ := r.counters["test_instrumented"].tags["result_type"]
 	assert.EqualValues(t, resultType, "success")
-	assert.NotNil(t, r.timers["testInstrumented.latency"].val)
+	assert.NotNil(t, r.timers["test_instrumented.latency"].val)
 }
 
 func TestInstrumentedCallFail(t *testing.T) {
@@ -339,16 +339,16 @@ func TestInstrumentedCallFail(t *testing.T) {
 	defer closer.Close()
 
 	r.cg.Add(1)
-	err := NewInstrumentedCall(s, "testInstrumented").Exec(func() error {
+	err := NewInstrumentedCall(s, "test_instrumented").Exec(func() error {
 		return errors.New("failure")
 	})
 	assert.NotNil(t, err)
 
 	r.WaitAll()
-	assert.EqualValues(t, 1, r.counters["testInstrumented"].val)
-	resultType, _ := r.counters["testInstrumented"].tags["result_type"]
+	assert.EqualValues(t, 1, r.counters["test_instrumented"].val)
+	resultType, _ := r.counters["test_instrumented"].tags["result_type"]
 	assert.EqualValues(t, resultType, "error")
-	assert.Nil(t, r.timers["testInstrumented.latency"])
+	assert.Nil(t, r.timers["test_instrumented.latency"])
 }
 
 func TestCachedReportLoop(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -57,9 +57,6 @@ type Scope interface {
 
 	// Capabilities returns a description of metrics reporting capabilities.
 	Capabilities() Capabilities
-
-	// InstrumentedCall returns an InstrumentedCall with the given name
-	InstrumentedCall(name string) InstrumentedCall
 }
 
 // Counter is the interface for emitting counter type metrics.
@@ -104,24 +101,6 @@ type Histogram interface {
 type Stopwatch struct {
 	start    time.Time
 	recorder StopwatchRecorder
-}
-
-// SuccessFilter determines whether an error should be considered success
-type SuccessFilter func(err error) bool
-
-// An InstrumentedCall allows tracking the success, errors, and timing of blocks of code
-type InstrumentedCall interface {
-	// Exec executes the given block of code, and records whether it succeeded or
-	// failed, and the amount of time that it took
-	Exec(f func() error) error
-
-	// ExecWithFilter executes the given block of code, and records whether it succeeded or
-	// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
-	// to be actually success for server logic), and the amount of time that it took
-	ExecWithFilter(f func() error, isSuccess SuccessFilter) error
-
-	// Tagged returns a new InstrumentedCall with the given set of tags
-	Tagged(tags map[string]string) InstrumentedCall
 }
 
 // NewStopwatch creates a new immutable stopwatch for recording the start
@@ -170,4 +149,22 @@ type Capabilities interface {
 
 	// Tagging returns whether the reporter has the capability for tagged metrics.
 	Tagging() bool
+}
+
+// SuccessFilter determines whether an error should be considered success
+type SuccessFilter func(err error) bool
+
+// ExecFn will be executed in an InstrumentedCall
+type ExecFn func() error
+
+// An InstrumentedCall allows tracking the success, errors, and timing of blocks of code
+type InstrumentedCall interface {
+	// Exec executes the given block of code, and records whether it succeeded or
+	// failed, and the amount of time that it took
+	Exec(f ExecFn) error
+
+	// ExecWithFilter executes the given block of code, and records whether it succeeded or
+	// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
+	// to be actually success for server logic), and the amount of time that it took
+	ExecWithFilter(f ExecFn, isSuccess SuccessFilter) error
 }

--- a/types.go
+++ b/types.go
@@ -151,8 +151,8 @@ type Capabilities interface {
 	Tagging() bool
 }
 
-// SuccessFilter determines whether an error should be considered success
-type SuccessFilter func(err error) bool
+// SuccessFilterFn determines whether an error should be considered success
+type SuccessFilterFn func(err error) bool
 
 // ExecFn will be executed in an InstrumentedCall
 type ExecFn func() error
@@ -166,5 +166,5 @@ type InstrumentedCall interface {
 	// ExecWithFilter executes the given block of code, and records whether it succeeded or
 	// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
 	// to be actually success for server logic), and the amount of time that it took
-	ExecWithFilter(f ExecFn, isSuccess SuccessFilter) error
+	ExecWithFilter(f ExecFn, isSuccess SuccessFilterFn) error
 }

--- a/types.go
+++ b/types.go
@@ -151,9 +151,6 @@ type Capabilities interface {
 	Tagging() bool
 }
 
-// SuccessFilterFn determines whether an error should be considered success
-type SuccessFilterFn func(err error) bool
-
 // ExecFn will be executed in an InstrumentedCall
 type ExecFn func() error
 
@@ -162,9 +159,4 @@ type InstrumentedCall interface {
 	// Exec executes the given block of code, and records whether it succeeded or
 	// failed, and the amount of time that it took
 	Exec(f ExecFn) error
-
-	// ExecWithFilter executes the given block of code, and records whether it succeeded or
-	// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
-	// to be actually success for server logic), and the amount of time that it took
-	ExecWithFilter(f ExecFn, isSuccess SuccessFilterFn) error
 }

--- a/types.go
+++ b/types.go
@@ -57,6 +57,9 @@ type Scope interface {
 
 	// Capabilities returns a description of metrics reporting capabilities.
 	Capabilities() Capabilities
+
+	// InstrumentedCall returns an InstrumentedCall with the given name
+	InstrumentedCall(name string) InstrumentedCall
 }
 
 // Counter is the interface for emitting counter type metrics.
@@ -101,6 +104,24 @@ type Histogram interface {
 type Stopwatch struct {
 	start    time.Time
 	recorder StopwatchRecorder
+}
+
+// SuccessFilter determines whether an error should be considered success
+type SuccessFilter func(err error) bool
+
+// An InstrumentedCall allows tracking the success, errors, and timing of blocks of code
+type InstrumentedCall interface {
+	// Exec executes the given block of code, and records whether it succeeded or
+	// failed, and the amount of time that it took
+	Exec(f func() error) error
+
+	// ExecWithFilter executes the given block of code, and records whether it succeeded or
+	// failed based on the result of a custom filter (e.g. the filter could determine a bad request error
+	// to be actually success for server logic), and the amount of time that it took
+	ExecWithFilter(f func() error, isSuccess SuccessFilter) error
+
+	// Tagged returns a new InstrumentedCall with the given set of tags
+	Tagged(tags map[string]string) InstrumentedCall
 }
 
 // NewStopwatch creates a new immutable stopwatch for recording the start


### PR DESCRIPTION
go-common's metric interface includes this functionality. It would be great to include it in tally as well since it simplifies application code, we don't need to explicitly handle timers and error cases every time we want to include metrics