### PR TITLE
Unpin facebook/clock

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,6 @@ import:
   subpackages:
   - statsd
 - package: github.com/facebookgo/clock
-  version: master
 - package: github.com/prometheus/client_golang
   version: ^0.8.0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
   subpackages:
   - statsd
 - package: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+  version: master
 - package: github.com/prometheus/client_golang
   version: ^0.8.0
   subpackages:


### PR DESCRIPTION
This change removes a hard pin on what is currently the master commit on facebook/clock. Like many Go projects, the project appears to have the release discipline of "never break master". With this pin, any project that depends on both tally and facebook/clock will need to use the exact same hash.

Alternately, I’d consider asking facebook/clock to cut a tagged semver release.