### PR TITLE
[Stopwatch] Add IsValid method to check if a Stopwatch has been initialized properly

### DIFF
--- a/types.go
+++ b/types.go
@@ -114,6 +114,11 @@ func (sw Stopwatch) Stop() {
 	sw.recorder.RecordStopwatch(sw.start)
 }
 
+// IsValid reports whether the StopWatch is valid for use.
+func (sw Stopwatch) IsValid() bool {
+	return sw.recorder != nil
+}
+
 // StopwatchRecorder is a recorder that is called when a stopwatch is
 // stopped with Stop().
 type StopwatchRecorder interface {

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package tally
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStopwatchReporter struct{}
+
+func (r *mockStopwatchReporter) RecordStopwatch(time.Time) {}
+
+func TestStopwatchIsValid(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		input    Stopwatch
+		expected bool
+	}{
+		{
+			input:    Stopwatch{},
+			expected: false,
+		},
+		{
+			input:    NewStopwatch(now, nil),
+			expected: false,
+		},
+		{
+			input:    NewStopwatch(now, new(mockStopwatchReporter)),
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.input.IsValid()
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
There are occasions where one may need to check if a `Stopwatch` has been initialized properly. One such example can be found in the [`m3x`](https://github.com/m3db/m3x/blob/master/instrument/methods.go#L66) package. However, since `Stopwatch` contains a `time.Time` field internally, comparing the given stopwatch to the zero value for a `Stopwatch` is insufficient. Consequently, this PR adds an `IsValid` method to `Stopwatch` to determine if it has been initialized with a recorder properly.

cc @robskillington @richardartoul

