### PR TITLE
add ExecWithFilter

### DIFF
--- a/instrument/call.go
+++ b/instrument/call.go
@@ -66,11 +66,11 @@ func (c *call) Exec(f ExecFn) error {
 	return nil
 }
 
-func (c *call) ExecWithFilter(f ExecFn, success SuccessFilter) error {
+func (c *call) ExecWithFilter(f ExecFn, success FilterFn) error {
 	sw := c.timing.Start()
 	err := f()
 
-	if err := f(); err != nil && !success(err) {
+	if err := f(); !success(err) {
 		c.error.Inc(1.0)
 		return err
 	}

--- a/instrument/call.go
+++ b/instrument/call.go
@@ -65,3 +65,18 @@ func (c *call) Exec(f ExecFn) error {
 
 	return nil
 }
+
+func (c *call) ExecWithFilter(f ExecFn, success SuccessFilter) error {
+	sw := c.timing.Start()
+	err := f()
+
+	if err := f(); err != nil && !success(err) {
+		c.error.Inc(1.0)
+		return err
+	}
+
+	sw.Stop()
+	c.success.Inc(1.0)
+
+	return err
+}

--- a/instrument/call.go
+++ b/instrument/call.go
@@ -66,17 +66,19 @@ func (c *call) Exec(f ExecFn) error {
 	return nil
 }
 
-func (c *call) ExecWithFilter(f ExecFn, success FilterFn) error {
-	sw := c.timing.Start()
-	err := f()
-
-	if err := f(); !success(err) {
-		c.error.Inc(1.0)
-		return err
-	}
-
-	sw.Stop()
-	c.success.Inc(1.0)
-
+// ExecWithFilter executes a function and records whether it succeeded or
+// failed, and the amount of time that it took. ExecWithFilter
+// will always return the error associted with the called function.
+// However, it will decide whether or not classify that error as
+// a success or failure based on the provided SuccessFilter.
+func ExecWithFilter(call Call, f ExecFn, success FilterFn) error {
+	var err error
+	call.Exec(func() error {
+		err = f()
+		if !success(err) {
+			return err
+		}
+		return nil
+	})
 	return err
 }

--- a/instrument/call_test.go
+++ b/instrument/call_test.go
@@ -73,7 +73,8 @@ func TestCallSuccessfulFail(t *testing.T) {
 	filter := func(_ error) bool { return true }
 
 	expected := errors.New("an error")
-	err := NewCall(s, "test_call").ExecWithFilter(func() error {
+	call := NewCall(s, "test_call")
+	err := ExecWithFilter(call, func() error {
 		return expected
 	}, filter)
 	assert.NotNil(t, err)
@@ -94,7 +95,8 @@ func TestCallFailFail(t *testing.T) {
 	filter := func(_ error) bool { return false }
 
 	expected := errors.New("an error")
-	err := NewCall(s, "test_call").ExecWithFilter(func() error {
+	call := NewCall(s, "test_call")
+	err := ExecWithFilter(call, func() error {
 		return expected
 	}, filter)
 	assert.NotNil(t, err)

--- a/instrument/types.go
+++ b/instrument/types.go
@@ -23,20 +23,21 @@ package instrument
 // ExecFn is an executable function that can be instrumented with a Call.
 type ExecFn func() error
 
-// SuccessFilter takes in an error and, if the error does not actually indicate
+// FilterFn takes in an error and, if the error does not actually indicate
 // a failure, returns true. If the error does actually indicate failure, the
 // function returns false.
-type SuccessFilter func(err error) bool
+type FilterFn func(err error) bool
 
 // Call allows tracking the successes, errors, and timing of functions.
 type Call interface {
 	// Exec executes a function and records whether it succeeded or
 	// failed, and the amount of time that it took.
 	Exec(f ExecFn) error
+
 	// Exec executes a function and records whether it succeeded or
 	// failed, and the amount of time that it took. ExecWithFilter
 	// will always return the error associted with the called function.
 	// However, it will decide whether or not classify that error as
 	// a success or failure based on the provided SuccessFilter.
-	ExecWithFilter(f ExecFn, filter SuccessFilter) error
+	ExecWithFilter(f ExecFn, filter FilterFn) error
 }

--- a/instrument/types.go
+++ b/instrument/types.go
@@ -23,9 +23,20 @@ package instrument
 // ExecFn is an executable function that can be instrumented with a Call.
 type ExecFn func() error
 
+// SuccessFilter takes in an error and, if the error does not actually indicate
+// a failure, returns true. If the error does actually indicate failure, the
+// function returns false.
+type SuccessFilter func(err error) bool
+
 // Call allows tracking the successes, errors, and timing of functions.
 type Call interface {
 	// Exec executes a function and records whether it succeeded or
 	// failed, and the amount of time that it took.
 	Exec(f ExecFn) error
+	// Exec executes a function and records whether it succeeded or
+	// failed, and the amount of time that it took. ExecWithFilter
+	// will always return the error associted with the called function.
+	// However, it will decide whether or not classify that error as
+	// a success or failure based on the provided SuccessFilter.
+	ExecWithFilter(f ExecFn, filter SuccessFilter) error
 }

--- a/instrument/types.go
+++ b/instrument/types.go
@@ -25,7 +25,7 @@ type ExecFn func() error
 
 // FilterFn takes in an error and, if the error does not actually indicate
 // a failure, returns true. If the error does actually indicate failure, the
-// function returns false.
+// function returns false. Can be used with the ExecWithFilter function.
 type FilterFn func(err error) bool
 
 // Call allows tracking the successes, errors, and timing of functions.
@@ -33,11 +33,4 @@ type Call interface {
 	// Exec executes a function and records whether it succeeded or
 	// failed, and the amount of time that it took.
 	Exec(f ExecFn) error
-
-	// Exec executes a function and records whether it succeeded or
-	// failed, and the amount of time that it took. ExecWithFilter
-	// will always return the error associted with the called function.
-	// However, it will decide whether or not classify that error as
-	// a success or failure based on the provided SuccessFilter.
-	ExecWithFilter(f ExecFn, filter FilterFn) error
 }


### PR DESCRIPTION
Sometimes, an instrumented call can return an error that we don't actually want to count as an error, but rather as a success. A classic use case for this is returning an error like "BadRequest" to a caller. In this case, the server hasn't actually caused an error. It's running as expected and we'd like to count this as a success. Never the less, we still need to propagate the error to the caller.

Let's add `ExecWithFilter`, it's the same as `Exec`, except we allow the user to define a function that let's use know whether or not to log the result as an error or if the call was actually a success despite the error.