### PR TITLE
Remove dependency on facebookgo/clock

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a15f875f47ee23f61d18d37812ef104f915f724fecd41178e8c4219973d63713
-updated: 2017-10-23T15:30:26.971475424-07:00
+hash: ff6c89fa45ba62e4b5a8dc4aa69c472be323df7d8c737665e841c40e1d718d1f
+updated: 2018-05-09T08:27:45.56646-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -10,13 +10,11 @@ imports:
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 138b925ccdf617776955904ba7759fce64406cec
   subpackages:
   - statsd
-- name: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/protobuf
-  version: 130e6b02ab059e7b717a096f397c5b60111cae74
+  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -24,7 +22,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -33,28 +31,26 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 6d76b79f239843a04e8ad8dfd8fcadfa3920236f
+  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
-  subpackages:
-  - xfs
+  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: go.uber.org/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: gopkg.in/validator.v2
-  version: 460c83432a98c35224a6fe352acf8b23e067ad06
+  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/golang/lint
@@ -66,7 +62,7 @@ testImports:
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ff6c89fa45ba62e4b5a8dc4aa69c472be323df7d8c737665e841c40e1d718d1f
-updated: 2018-05-09T08:27:45.56646-04:00
+hash: a15f875f47ee23f61d18d37812ef104f915f724fecd41178e8c4219973d63713
+updated: 2017-10-23T15:30:26.971475424-07:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -10,11 +10,11 @@ imports:
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 138b925ccdf617776955904ba7759fce64406cec
+  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
   subpackages:
   - statsd
 - name: github.com/golang/protobuf
-  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+  version: 130e6b02ab059e7b717a096f397c5b60111cae74
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -22,7 +22,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -31,26 +31,28 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  version: 6d76b79f239843a04e8ad8dfd8fcadfa3920236f
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 1878d9fbb537119d24b21ca07effd591627cd160
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  subpackages:
+  - xfs
 - name: go.uber.org/atomic
-  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: gopkg.in/validator.v2
-  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+  version: 460c83432a98c35224a6fe352acf8b23e067ad06
 - name: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports:
 - name: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
   subpackages:
   - spew
 - name: github.com/golang/lint
@@ -62,7 +64,7 @@ testImports:
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,8 +5,6 @@ import:
   version: ~3.1.0
   subpackages:
   - statsd
-- package: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - package: github.com/prometheus/client_golang
   version: ^0.8.0
   subpackages:

--- a/scope.go
+++ b/scope.go
@@ -25,8 +25,6 @@ import (
 	"io"
 	"sync"
 	"time"
-
-	"github.com/facebookgo/clock"
 )
 
 var (
@@ -35,7 +33,7 @@ var (
 	// DefaultSeparator is the default separator used to join nested scopes
 	DefaultSeparator = "."
 
-	globalClock = clock.New()
+	globalNow = time.Now
 
 	defaultScopeBuckets = DurationBuckets{
 		0 * time.Millisecond,

--- a/stats.go
+++ b/stats.go
@@ -181,11 +181,11 @@ func (t *timer) Record(interval time.Duration) {
 }
 
 func (t *timer) Start() Stopwatch {
-	return NewStopwatch(globalClock.Now(), t)
+	return NewStopwatch(globalNow(), t)
 }
 
 func (t *timer) RecordStopwatch(stopwatchStart time.Time) {
-	d := globalClock.Now().Sub(stopwatchStart)
+	d := globalNow().Sub(stopwatchStart)
 	t.Record(d)
 }
 
@@ -367,11 +367,11 @@ func (h *histogram) RecordDuration(value time.Duration) {
 }
 
 func (h *histogram) Start() Stopwatch {
-	return NewStopwatch(globalClock.Now(), h)
+	return NewStopwatch(globalNow(), h)
 }
 
 func (h *histogram) RecordStopwatch(stopwatchStart time.Time) {
-	d := globalClock.Now().Sub(stopwatchStart)
+	d := globalNow().Sub(stopwatchStart)
 	h.RecordDuration(d)
 }
 


### PR DESCRIPTION
This is to fix the issues encountered in https://github.com/uber-go/tally/pull/60