### PR TITLE
Use semver dependency on Apache Thrift

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,20 @@
-hash: d0097dab7d41d8ef6443539484d3e6a7ade8e172da717ca6f2b6b0de0419e5d3
-updated: 2018-05-17T10:52:52.541763-04:00
+hash: 20082900e43a2e140264cd95d5d7be6a88c14256890a7db43b237353d09dbc63
+updated: 2018-07-17T16:33:25.073511-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 91c326c3f7bd20f0226d3d1c289dd9f8ce28d33d
+  version: 138b925ccdf617776955904ba7759fce64406cec
   subpackages:
   - statsd
 - name: github.com/golang/protobuf
-  version: 130e6b02ab059e7b717a096f397c5b60111cae74
+  version: 14aad3d5ea4c323bcd7a2137e735da24a76e814c
   subpackages:
   - proto
 - name: github.com/m3db/prometheus_client_golang
@@ -39,18 +39,18 @@ imports:
   subpackages:
   - pbutil
 - name: go.uber.org/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: gopkg.in/validator.v2
-  version: 460c83432a98c35224a6fe352acf8b23e067ad06
+  version: 135c24b11c19e52befcae2ec3fca5d9b78c4e98e
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: a476722483882dd40b8111f0eb64e1d7f43f56e4
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/golang/lint
@@ -62,7 +62,7 @@ testImports:
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
 - package: github.com/m3db/prometheus_procfs
   version: 1878d9fbb537119d24b21ca07effd591627cd160
 - package: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  version: '>=0.9.3, <0.11.0'
   subpackages:
   - lib/go/thrift
 - package: go.uber.org/atomic


### PR DESCRIPTION
Apache Thrift made a breaking api change in the 0.11 series. This package relies on the ~0.10 API. 
Currently downstream packages using dep do not inherit this package's transitive dependency constraint on apache thrift because dep does not consider revision pins when importing constraints from alternate dependency managers. By using a semver range instead of a direct pin.

Another parallel path is to propose amending Dep to consider Glide revision pins as valid transitive constraints. We can do that unilaterally in our fork of dep but it would be much better if we worked with upstream. This pull request gets us out of the immediate pain and unblocks migration to dep within Uber.