### PR TITLE
enable the tenancy for tally

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -21,8 +21,6 @@ import:
   - lib/go/thrift
 - package: go.uber.org/atomic
   version: ^1
-- package: code.uber.internal/infra/tenancy-client-go.git
-  version: master
 testImport:
 - package: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,8 @@ import:
   - lib/go/thrift
 - package: go.uber.org/atomic
   version: ^1
+- package: code.uber.internal/infra/tenancy-client-go.git
+  version: master
 testImport:
 - package: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b

--- a/scope.go
+++ b/scope.go
@@ -21,9 +21,9 @@
 package tally
 
 import (
-	"code.uber.internal/infra/tenancy-client-go.git/tenancyfx"
+	"code.uber.internal/infra/tenancy-client-go/tenancyfx"
 	"fmt"
-	"golang.org/x/net/context"
+	"context"
 	"io"
 	"sync"
 	"time"

--- a/scope.go
+++ b/scope.go
@@ -55,8 +55,11 @@ var (
 )
 
 const (
+	// TestingTenancy is used to check the passing tenancy string
 	TestingTenancy     = "testing"
+	// ProductionTenancy is used to check the passing tenancy string
 	ProductionTenancy  = "production"
+	// TenancyKey is the key value for tenancy tag
 	TenancyKey         = "request-tenancy"
 )
 type scope struct {

--- a/scope_test.go
+++ b/scope_test.go
@@ -21,13 +21,13 @@
 package tally
 
 import (
-	"code.uber.internal/infra/tenancy-client-go.git/tenancyfx"
+	"code.uber.internal/infra/tenancy-client-go/tenancyfx"
 	"encoding/base64"
 	"encoding/json"
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
 	"go.uber.org/config"
-	"golang.org/x/net/context"
+	"context"
 	"math"
 	"sync"
 	"sync/atomic"

--- a/types.go
+++ b/types.go
@@ -21,7 +21,7 @@
 package tally
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"fmt"
 	"sort"
 	"time"

--- a/types.go
+++ b/types.go
@@ -21,6 +21,7 @@
 package tally
 
 import (
+	"golang.org/x/net/context"
 	"fmt"
 	"sort"
 	"time"
@@ -50,7 +51,10 @@ type Scope interface {
 	Histogram(name string, buckets Buckets) Histogram
 
 	// Tagged returns a new child scope with the given tags and current tags.
-	Tagged(tags map[string]string) Scope
+	Tagged(tags map[string]string, ctx ...context.Context) Scope
+
+	// TaggedWithContext required the context to extract the tenancy value, return a new child scope with tenancy tag plus given tags
+	TaggedWithContext(ctx context.Context, tags map[string]string) Scope
 
 	// SubScope returns a new child scope appending a further name prefix.
 	SubScope(name string) Scope

--- a/types.go
+++ b/types.go
@@ -21,7 +21,6 @@
 package tally
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -51,10 +50,10 @@ type Scope interface {
 	Histogram(name string, buckets Buckets) Histogram
 
 	// Tagged returns a new child scope with the given tags and current tags.
-	Tagged(tags map[string]string, ctx ...context.Context) Scope
+	Tagged(tags map[string]string, tenancys ...string) Scope
 
-	// TaggedWithContext required the context to extract the tenancy value, return a new child scope with tenancy tag plus given tags
-	TaggedWithContext(ctx context.Context, tags map[string]string) Scope
+	// TaggedWithTenancy required the context to extract the tenancy value, return a new child scope with tenancy tag plus given tags
+	TaggedWithTenancy(tenancy string, tags map[string]string) Scope
 
 	// SubScope returns a new child scope appending a further name prefix.
 	SubScope(name string) Scope


### PR DESCRIPTION
This issue is going to enable the tenancy for tally go library.

We extract the tenancy value from the jaeger baggage which is inside the context. Then we check the tenancy value (either "production" or "testing"), and set a tenancy tag in the tally scope.

We modified the Tagged() function to pass an optional context as parameter, and also provided a TaggedWithContext() function with context as one restrict parameter.