### PR TITLE
Add expiration functionality to metrics and scopes

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -313,11 +313,11 @@ func (s *scope) cachedReport(c CachedStatsReporter) bool {
 }
 
 func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
-	var i int
-
 	if len(tracker.expiredCounters) > 0 {
 		s.cm.Lock()
 		for name, counters := range s.counters {
+			var i int
+
 			for _, counter := range counters {
 				if _, exists := tracker.expiredCounters[counter]; !exists ||
 					(exists && !counter.expired()) {
@@ -331,8 +331,6 @@ func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
 			} else {
 				s.counters[name] = counters[:i]
 			}
-
-			i = 0
 		}
 
 		tracker.numCounters = len(s.counters)
@@ -342,6 +340,8 @@ func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
 	if len(tracker.expiredGauges) > 0 {
 		s.gm.Lock()
 		for name, gauges := range s.gauges {
+			var i int
+
 			for _, gauge := range gauges {
 				if _, exists := tracker.expiredGauges[gauge]; !exists ||
 					(exists && !gauge.expired()) {
@@ -355,8 +355,6 @@ func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
 			} else {
 				s.gauges[name] = gauges[:i]
 			}
-
-			i = 0
 		}
 
 		tracker.numGauges = len(s.gauges)
@@ -366,6 +364,8 @@ func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
 	if len(tracker.expiredHistograms) > 0 {
 		s.hm.Lock()
 		for name, histograms := range s.histograms {
+			var i int
+
 			for _, histogram := range histograms {
 				if _, exists := tracker.expiredHistograms[histogram]; !exists ||
 					(exists && !histogram.expired()) {
@@ -379,8 +379,6 @@ func (s *scope) clearExpiredMetrics(tracker *scopeExpiryTracker) {
 			} else {
 				s.histograms[name] = histograms[:i]
 			}
-
-			i = 0
 		}
 
 		tracker.numHistograms = len(s.histograms)
@@ -458,6 +456,8 @@ func (s *scope) reportRegistryWithLock() {
 
 				if mets == 0 {
 					delete(s.registry.subscopes, name)
+				} else {
+					atomic.StoreUint32(&ss.expired, 0)
 				}
 			}
 		}
@@ -792,7 +792,7 @@ func (s *scope) Snapshot() Snapshot {
 							values[k] = 0
 						}
 
-						values[k] = values[k] + v
+						values[k] += v
 					}
 
 					for k, v := range histograms[i].snapshotDurations() {
@@ -800,7 +800,7 @@ func (s *scope) Snapshot() Snapshot {
 							durations[k] = 0
 						}
 
-						durations[k] = durations[k] + v
+						durations[k] += v
 					}
 				}
 

--- a/scope.go
+++ b/scope.go
@@ -204,11 +204,12 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 // report dumps all aggregated stats into the reporter. Should be called automatically by the root scope periodically.
 func (s *scope) report(r StatsReporter) bool {
 	tracker := newScopeExpiryTracker()
+	nowUnix := globalNow().Unix()
 
 	s.cm.RLock()
 	for name, counters := range s.counters {
 		for _, counter := range counters {
-			if counter.report(s.fullyQualifiedName(name), s.tags, r) {
+			if counter.report(s.fullyQualifiedName(name), s.tags, r, nowUnix) {
 				tracker.expiredCounters[counter] = struct{}{}
 			}
 		}
@@ -220,7 +221,7 @@ func (s *scope) report(r StatsReporter) bool {
 	s.gm.RLock()
 	for name, gauges := range s.gauges {
 		for _, gauge := range gauges {
-			if gauge.report(s.fullyQualifiedName(name), s.tags, r) {
+			if gauge.report(s.fullyQualifiedName(name), s.tags, r, nowUnix) {
 				tracker.expiredGauges[gauge] = struct{}{}
 			}
 		}
@@ -236,7 +237,7 @@ func (s *scope) report(r StatsReporter) bool {
 	s.hm.RLock()
 	for name, histograms := range s.histograms {
 		for _, histogram := range histograms {
-			if histogram.report(s.fullyQualifiedName(name), s.tags, r) {
+			if histogram.report(s.fullyQualifiedName(name), s.tags, r, nowUnix) {
 				tracker.expiredHistograms[histogram] = struct{}{}
 			}
 		}
@@ -258,11 +259,12 @@ func (s *scope) report(r StatsReporter) bool {
 
 func (s *scope) cachedReport(c CachedStatsReporter) bool {
 	tracker := newScopeExpiryTracker()
+	nowUnix := globalNow().Unix()
 
 	s.cm.RLock()
 	for _, counters := range s.counters {
 		for _, counter := range counters {
-			if counter.cachedReport() {
+			if counter.cachedReport(nowUnix) {
 				tracker.expiredCounters[counter] = struct{}{}
 			}
 		}
@@ -274,7 +276,7 @@ func (s *scope) cachedReport(c CachedStatsReporter) bool {
 	s.gm.RLock()
 	for _, gauges := range s.gauges {
 		for _, gauge := range gauges {
-			if gauge.cachedReport() {
+			if gauge.cachedReport(nowUnix) {
 				tracker.expiredGauges[gauge] = struct{}{}
 			}
 		}
@@ -290,7 +292,7 @@ func (s *scope) cachedReport(c CachedStatsReporter) bool {
 	s.hm.RLock()
 	for _, histograms := range s.histograms {
 		for _, histogram := range histograms {
-			if histogram.cachedReport() {
+			if histogram.cachedReport(nowUnix) {
 				tracker.expiredHistograms[histogram] = struct{}{}
 			}
 		}

--- a/scope.go
+++ b/scope.go
@@ -649,6 +649,8 @@ func (s *scope) Snapshot() Snapshot {
 				id := KeyForPrefixedStringMap(name, tags)
 				var val int64
 				for _, counter := range counters {
+					// If there are multiple counters created due to expiry,
+					// add the values together
 					val += counter.snapshot()
 				}
 
@@ -666,6 +668,8 @@ func (s *scope) Snapshot() Snapshot {
 			if len(gauges) > 0 {
 				name := ss.fullyQualifiedName(key)
 				id := KeyForPrefixedStringMap(name, tags)
+				// If there are multiple gauges created due to expiry,
+				// pick the value of the first gauge
 				snap.gauges[id] = &gaugeSnapshot{
 					name:  name,
 					tags:  tags,
@@ -702,6 +706,8 @@ func (s *scope) Snapshot() Snapshot {
 				values := histograms[0].snapshotValues()
 				durations := histograms[0].snapshotDurations()
 
+				// If there are multiple histograms created due to expiry,
+				// combine the values
 				for i := 1; i < len(histograms); i++ {
 					for k, v := range histograms[i].snapshotValues() {
 						if _, exists := values[k]; !exists {

--- a/scope.go
+++ b/scope.go
@@ -156,7 +156,9 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 		opts.DefaultBuckets = defaultScopeBuckets
 	}
 
-	if opts.ExpiryPeriod == 0 {
+	if opts.ExpiryPeriod < time.Second {
+		// ExpiryPeriod cannot be less than a second since we
+		// perform expiry calcuation on time.Unix()
 		opts.ExpiryPeriod = defaultExpiry
 	}
 
@@ -430,7 +432,7 @@ func (s *scope) getCurrentScope() *scope {
 		registryName := scopeRegistryKey(s.prefix, s.tags)
 		s.registry.RLock()
 		curScope, exists := s.registry.subscopes[registryName]
-		s.registry.RLock()
+		s.registry.RUnlock()
 
 		if exists {
 			// A new scope exists, return that instead of the current one

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -22,6 +22,7 @@ package tally
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 )
@@ -119,5 +120,58 @@ func BenchmarkHistogramExisting(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		root.Histogram("foo", DefaultBuckets)
+	}
+}
+
+func Benchmark1MapMetric(b *testing.B) {
+	benchMapMetrics(1, b)
+}
+
+func Benchmark1SliceMetric(b *testing.B) {
+	benchSliceMetrics(1, b)
+}
+
+func Benchmark10MapMetric(b *testing.B) {
+	benchMapMetrics(10, b)
+}
+
+func Benchmark10SliceMetric(b *testing.B) {
+	benchSliceMetrics(10, b)
+}
+
+func Benchmark100MapMetric(b *testing.B) {
+	benchMapMetrics(100, b)
+}
+
+func Benchmark100SliceMetric(b *testing.B) {
+	benchSliceMetrics(100, b)
+}
+
+func benchMapMetrics(n int, b *testing.B) {
+	mets := make(map[string]*counter, n)
+	for i := 0; i < n; i++ {
+		mets[testFullyQualifiedName+strconv.Itoa(i)] = &counter{}
+	}
+
+	for i := 0; i < b.N; i++ {
+		name := testFullyQualifiedName + strconv.Itoa(rand.Int()%n)
+		mets[name].Inc(1)
+	}
+}
+
+func benchSliceMetrics(n int, b *testing.B) {
+	mets := make([]*testNamedCounter, 0, n)
+	for i := 0; i < n; i++ {
+		mets = append(mets, &testNamedCounter{name: testFullyQualifiedName + strconv.Itoa(i)})
+	}
+
+	for i := 0; i < b.N; i++ {
+		name := testFullyQualifiedName + strconv.Itoa(rand.Int()%n)
+		for _, met := range mets {
+			if met.name == name {
+				met.Inc(1)
+				break
+			}
+		}
 	}
 }

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -56,6 +56,18 @@ func BenchmarkCounterAllocation(b *testing.B) {
 	}
 }
 
+func BenchmarkMetricLookup(b *testing.B) {
+	root, _ := NewRootScope(ScopeOptions{
+		Prefix:   "funkytown",
+		Reporter: NullStatsReporter,
+	}, 0)
+
+	for i := 0; i < b.N; i++ {
+		root.SubScope("myScope").Tagged(
+			map[string]string{"testTag": "testValue", "testTag2": "testValue"}).Counter("test").Inc(1)
+	}
+}
+
 func BenchmarkSanitizedCounterAllocation(b *testing.B) {
 	root, _ := NewRootScope(ScopeOptions{
 		Prefix:          "funkytown",

--- a/scope_test.go
+++ b/scope_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testFullyQualifiedName = "test.fully.qualified.name"
+
 var (
 	// alphanumericSanitizerOpts is the options to create a sanitizer which uses
 	// the alphanumeric SanitizeFn.
@@ -49,6 +51,17 @@ var (
 		ReplacementCharacter: DefaultReplacementCharacter,
 	}
 )
+
+type testNamedCounter struct {
+	prev        int64
+	curr        int64
+	cachedCount CachedCount
+	name        string
+}
+
+func (c *testNamedCounter) Inc(v int64) {
+	atomic.AddInt64(&c.curr, v)
+}
 
 type testIntValue struct {
 	val      int64

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -57,7 +57,7 @@ func BenchmarkCounterInc(b *testing.B) {
 func BenchmarkReportCounterNoData(b *testing.B) {
 	c := &counter{}
 	for n := 0; n < b.N; n++ {
-		c.report("foo", nil, NullStatsReporter)
+		c.report("foo", nil, NullStatsReporter, 0)
 	}
 }
 
@@ -65,7 +65,7 @@ func BenchmarkReportCounterWithData(b *testing.B) {
 	c := &counter{}
 	for n := 0; n < b.N; n++ {
 		c.Inc(1)
-		c.report("foo", nil, NullStatsReporter)
+		c.report("foo", nil, NullStatsReporter, 0)
 	}
 }
 
@@ -79,7 +79,7 @@ func BenchmarkGaugeSet(b *testing.B) {
 func BenchmarkReportGaugeNoData(b *testing.B) {
 	g := &gauge{}
 	for n := 0; n < b.N; n++ {
-		g.report("bar", nil, NullStatsReporter)
+		g.report("bar", nil, NullStatsReporter, 0)
 	}
 }
 
@@ -87,7 +87,7 @@ func BenchmarkReportGaugeWithData(b *testing.B) {
 	g := &gauge{}
 	for n := 0; n < b.N; n++ {
 		g.Update(73)
-		g.report("bar", nil, NullStatsReporter)
+		g.report("bar", nil, NullStatsReporter, 0)
 	}
 }
 

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -25,8 +25,24 @@ import (
 	"time"
 )
 
+func BenchmarkSimpleCounterInc(b *testing.B) {
+	c := &testSimpleCounter{}
+	for n := 0; n < b.N; n++ {
+		c.Inc(1)
+	}
+}
+
+func BenchmarkAlwaysCheckCounterInc(b *testing.B) {
+	s := newRootScope(ScopeOptions{Reporter: newTestStatsReporter()}, 0)
+	c := newTestAlwaysCheckCounter("", s)
+	for n := 0; n < b.N; n++ {
+		c.Inc(1)
+	}
+}
+
 func BenchmarkCounterInc(b *testing.B) {
-	c := &counter{}
+	scope := NewTestScope("", nil)
+	c := scope.Counter("test")
 	for n := 0; n < b.N; n++ {
 		c.Inc(1)
 	}

--- a/stats_benchmark_test.go
+++ b/stats_benchmark_test.go
@@ -32,6 +32,12 @@ func BenchmarkSimpleCounterInc(b *testing.B) {
 	}
 }
 
+func BenchmarkSimpleCounterExpiredInc(b *testing.B) {
+	c := &testSimpleCounter{}
+	for n := 0; n < b.N; n++ {
+		c.IncWithExpiredCheck(1)
+	}
+}
 func BenchmarkAlwaysCheckCounterInc(b *testing.B) {
 	s := newRootScope(ScopeOptions{Reporter: newTestStatsReporter()}, 0)
 	c := newTestAlwaysCheckCounter("", s)

--- a/stats_test.go
+++ b/stats_test.go
@@ -185,7 +185,7 @@ func TestHistogramValueSamples(t *testing.T) {
 		h.RecordValue(offset + rand.Float64()*10)
 	}
 
-	h.report(h.name, h.tags, r)
+	h.report("h1", h.tags, r)
 
 	assert.Equal(t, 3, r.valueSamples[10.0])
 	assert.Equal(t, 5, r.valueSamples[60.0])
@@ -208,7 +208,7 @@ func TestHistogramDurationSamples(t *testing.T) {
 			time.Duration(rand.Float64()*float64(10*time.Millisecond)))
 	}
 
-	h.report(h.name, h.tags, r)
+	h.report("h1", h.tags, r)
 
 	assert.Equal(t, 3, r.durationSamples[10*time.Millisecond])
 	assert.Equal(t, 5, r.durationSamples[60*time.Millisecond])

--- a/stats_test.go
+++ b/stats_test.go
@@ -134,15 +134,15 @@ func TestCounter(t *testing.T) {
 	r := newStatsTestReporter()
 
 	counter.Inc(1)
-	counter.report("", nil, r)
+	counter.report("", nil, r, 0)
 	assert.Equal(t, int64(1), r.last)
 
 	counter.Inc(1)
-	counter.report("", nil, r)
+	counter.report("", nil, r, 0)
 	assert.Equal(t, int64(1), r.last)
 
 	counter.Inc(1)
-	counter.report("", nil, r)
+	counter.report("", nil, r, 0)
 	assert.Equal(t, int64(1), r.last)
 }
 
@@ -151,12 +151,12 @@ func TestGauge(t *testing.T) {
 	r := newStatsTestReporter()
 
 	gauge.Update(42)
-	gauge.report("", nil, r)
+	gauge.report("", nil, r, 0)
 	assert.Equal(t, float64(42), r.last)
 
 	gauge.Update(1234)
 	gauge.Update(5678)
-	gauge.report("", nil, r)
+	gauge.report("", nil, r, 0)
 	assert.Equal(t, float64(5678), r.last)
 }
 
@@ -185,7 +185,7 @@ func TestHistogramValueSamples(t *testing.T) {
 		h.RecordValue(offset + rand.Float64()*10)
 	}
 
-	h.report("h1", h.tags, r)
+	h.report("h1", h.tags, r, 0)
 
 	assert.Equal(t, 3, r.valueSamples[10.0])
 	assert.Equal(t, 5, r.valueSamples[60.0])
@@ -208,7 +208,7 @@ func TestHistogramDurationSamples(t *testing.T) {
 			time.Duration(rand.Float64()*float64(10*time.Millisecond)))
 	}
 
-	h.report("h1", h.tags, r)
+	h.report("h1", h.tags, r, 0)
 
 	assert.Equal(t, 3, r.durationSamples[10*time.Millisecond])
 	assert.Equal(t, 5, r.durationSamples[60*time.Millisecond])

--- a/stats_test.go
+++ b/stats_test.go
@@ -30,12 +30,20 @@ import (
 )
 
 type testSimpleCounter struct {
-	prev int64
-	curr int64
+	prev    int64
+	curr    int64
+	expired uint32
 }
 
 func (c *testSimpleCounter) Inc(v int64) {
 	atomic.AddInt64(&c.curr, v)
+}
+
+func (c *testSimpleCounter) IncWithExpiredCheck(v int64) {
+	atomic.AddInt64(&c.curr, v)
+	if atomic.CompareAndSwapUint32(&c.expired, 1, 0) {
+		c.prev = 1
+	}
 }
 
 type testAlwaysCheckCounter struct {


### PR DESCRIPTION
Currently, all created scopes and metrics (counters, gauges, timers and histograms) will live forever and all metrics will be checked in every report interval. For long lived  process use cases where short lived metrics are created commonly, the memory usage will grow over time with no mechanism to delete metrics that are no longer in use since we hold a reference to them in the scopes and registries.

This change adds a configurable expiration time in which scopes and metrics will be removed from the registry. The change is complicated by the fact that users may have their own references to these scopes and metric objects, which means that even if we removed our reference from the registry and scopes, we cannot safely clean these objects up (place them back into pools etc). Furthermore, if a user updates one of these metrics after it has expired, we need to re-insert that metric (and parent scope) back into the registry in order for the metric to be flushed successfully.

The overall logic is as follows:

- Scopes will only expire after the expiration period has elapsed and all of it's metrics have expired. Upon expiry, a scope will be removed from the registry.
- If a user holds onto a reference of an expired scope and calls to create a subscope or metric, we will check to see if another scope with the same prefix and tags has already been created and inserted into the registry in the meantime. If so, we will add subscopes and metrics to the new scope instead. If not, we will re-insert the scope back into the registry. There will only ever be one scope per name and tag combination in the registry at once, even though many may exist due to expiration and held references. This way, expired scopes will never contain non expired metrics and subscopes.
- Metrics will be expired if there have been no updates or increment calls for the duration of the expiration period. This check is applied during a report call to avoid a performance hit on the increment or update calls. Expired metrics will be removed from their parent scopes and will be GC'd as long as the user does not old a direct reference to them.
- If a user holds a direct reference to an expired metric and calls an increment or update, we will reinsert the metric to the appropriate scope in the registry and start reporting its value once again.
- If a scope has no reporter, the metrics will not be expired. 

There are no interface changes and all existing tests continue to pass.