### PR TITLE
Add ability to use a non-default registry

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -74,8 +74,8 @@ type RegistryConfiguration struct {
 }
 
 // DefaultRegistryConfiguration returns the default registry configuration.
-// By default the default Prometheus registry is used and no collectors
-// are registered.
+// By default the default Prometheus registry already has several collectors
+// registered, such as the Go collector and the Process collector.
 func DefaultRegistryConfiguration() RegistryConfiguration {
 	return RegistryConfiguration{
 		Default: true,

--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -273,6 +273,12 @@ type Options struct {
 func NewReporter(opts Options) Reporter {
 	if opts.Registerer == nil {
 		opts.Registerer = prom.DefaultRegisterer
+	} else {
+		// A specific registerer was set, check if it's a registry and if
+		// no gatherer was set, then use that as the gatherer
+		if reg, ok := opts.Registerer.(*prom.Registry); ok && opts.Gatherer == nil {
+			opts.Gatherer = reg
+		}
 	}
 	if opts.Gatherer == nil {
 		opts.Gatherer = prom.DefaultGatherer


### PR DESCRIPTION
This allows users to specifically enable which collectors they'd like if they are willing to use a non-default registry.