### PR TITLE
Fix OnRegisterError not being called correctly when listen port in use

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -149,7 +149,7 @@ func (c Configuration) NewReporter(
 		mux.Handle(path, reporter.HTTPHandler())
 		go func() {
 			if err := http.ListenAndServe(addr, mux); err != nil {
-				configOpts.OnError(err)
+				opts.OnRegisterError(err)
 			}
 		}()
 	}

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -34,6 +34,8 @@ func TestListenErrorCallsOnRegisterError(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
+	defer func() { _ = listener.Close() }()
+
 	assert.NotPanics(t, func() {
 		cfg := Configuration{
 			ListenAddress: listener.Addr().String(),

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package prometheus
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenErrorCallsOnRegisterError(t *testing.T) {
+	// Ensure that Listen error calls default OnRegisterError to panic
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	assert.NotPanics(t, func() {
+		cfg := Configuration{
+			ListenAddress: listener.Addr().String(),
+			OnError: "log",
+		}
+		_, _ = cfg.NewReporter(ConfigurationOptions{})
+		time.Sleep(time.Second)
+	})
+}
+


### PR DESCRIPTION
This sets the correct error callback to use when a listen address conflict occurs with the Prometheus reporter, it will correctly panic/call whatever callback configured rather than experiencing a nil pointer panic.