### PR TITLE
Proposal to create a NewRegistry by default

### DIFF
--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -272,7 +272,7 @@ type Options struct {
 // https://godoc.org/github.com/prometheus/client_golang/prometheus#SummaryOpts for more details.
 func NewReporter(opts Options) Reporter {
 	if opts.Registerer == nil {
-		opts.Registerer = prom.DefaultRegisterer
+		opts.Registerer = prom.NewRegistry()
 	} else {
 		// A specific registerer was set, check if it's a registry and if
 		// no gatherer was set, then use that as the gatherer


### PR DESCRIPTION
Currently the default behavior on creating a NewReporter is to use the prometheus DefaultReporter, which can result in, for instance, difficult to track down panics due to duplicate metric registry when spinning up two different reporters in separate test cases. I would like to propose either creating a NewRegistry by default, or at least documenting the default behavior of this method. This is just a suggestion and I'm open to learning the reason that a global is used by default.