### PR TITLE
Flush reporter from root scope only

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -202,11 +202,9 @@ func (s *scope) report(r StatsReporter) {
 		histogram.report(s.fullyQualifiedName(name), s.tags, r)
 	}
 	s.hm.RUnlock()
-
-	r.Flush()
 }
 
-func (s *scope) cachedReport(c CachedStatsReporter) {
+func (s *scope) cachedReport() {
 	s.cm.RLock()
 	for _, counter := range s.counters {
 		counter.cachedReport()
@@ -226,8 +224,6 @@ func (s *scope) cachedReport(c CachedStatsReporter) {
 		histogram.cachedReport()
 	}
 	s.hm.RUnlock()
-
-	c.Flush()
 }
 
 // reportLoop is used by the root scope for periodic reporting
@@ -266,10 +262,12 @@ func (s *scope) reportRegistryWithLock() {
 		for _, ss := range s.registry.subscopes {
 			ss.report(s.reporter)
 		}
+		s.reporter.Flush()
 	} else if s.cachedReporter != nil {
 		for _, ss := range s.registry.subscopes {
-			ss.cachedReport(s.cachedReporter)
+			ss.cachedReport()
 		}
+		s.cachedReporter.Flush()
 	}
 	s.registry.RUnlock()
 }


### PR DESCRIPTION
While changing backend reporting/batching settings, I noticed some very surprising behaviour, as if Flush() was called much more frequently than it should. Given the explicit reporting interval settings and Close() semantics, I would not expect Flush() to be called from each sub-scope, just from the root.

This PR moves the flush logic to reportRegistryWithLock(), so it's called only in the report loop or on root scope closure, so the underlying reporter does not do `$subscope_count` flushes every reporting cycle.