### PR TITLE
Add HistogramBucketTagPrecision to m3 config

### DIFF
--- a/m3/config.go
+++ b/m3/config.go
@@ -45,6 +45,10 @@ type Configuration struct {
 
 	// IncludeHost is whether or not to include host tag.
 	IncludeHost bool `yaml:"includeHost"`
+
+	// HistogramBucketTagPrecision is precision to use when formatting the metric tag
+	// with the histogram bucket bound values.
+	HistogramBucketTagPrecision uint `yaml:"histogramBucketTagPrecision"`
 }
 
 // NewReporter creates a new M3 reporter from this configuration.
@@ -54,12 +58,13 @@ func (c Configuration) NewReporter() (Reporter, error) {
 		hostPorts = []string{c.HostPort}
 	}
 	return NewReporter(Options{
-		HostPorts:          hostPorts,
-		Service:            c.Service,
-		Env:                c.Env,
-		CommonTags:         c.CommonTags,
-		MaxQueueSize:       c.Queue,
-		MaxPacketSizeBytes: c.PacketSize,
-		IncludeHost:        c.IncludeHost,
+		HostPorts:                   hostPorts,
+		Service:                     c.Service,
+		Env:                         c.Env,
+		CommonTags:                  c.CommonTags,
+		MaxQueueSize:                c.Queue,
+		MaxPacketSizeBytes:          c.PacketSize,
+		IncludeHost:                 c.IncludeHost,
+		HistogramBucketTagPrecision: c.HistogramBucketTagPrecision,
 	})
 }


### PR DESCRIPTION
Add HistogramBucketTagPrecision to m3 config to set the value while creating the new reporter.