### PR TITLE
m3: Speed up calculateSize and reduce allocations

### DIFF
--- a/m3/customtransports/m3_calc_transport.go
+++ b/m3/customtransports/m3_calc_transport.go
@@ -48,6 +48,20 @@ func (p *TCalcTransport) Write(buf []byte) (int, error) {
 	return len(buf), nil
 }
 
+// WriteByte adds 1 to the count
+// Required to maintain thrift.TRichTransport interface
+func (p *TCalcTransport) WriteByte(byte) error {
+	atomic.AddInt32(&p.count, 1)
+	return nil
+}
+
+// WriteString adds the length of the string to the count
+// Required to maintain thrift.TRichTransport interface
+func (p *TCalcTransport) WriteString(s string) (int, error) {
+	atomic.AddInt32(&p.count, int32(len(s)))
+	return len(s), nil
+}
+
 // IsOpen does nothing as transport is not maintaining a connection
 // Required to maintain thrift.TTransport interface
 func (p *TCalcTransport) IsOpen() bool {
@@ -69,6 +83,12 @@ func (p *TCalcTransport) Close() error {
 // Read does nothing as it's not required for calculations
 // Required to maintain thrift.TTransport interface
 func (p *TCalcTransport) Read(buf []byte) (int, error) {
+	return 0, nil
+}
+
+// ReadByte does nothing as it's not required for calculations
+// Required to maintain thrift.TRichTransport interface
+func (p *TCalcTransport) ReadByte() (byte, error) {
 	return 0, nil
 }
 

--- a/m3/reporter_benchmark_test.go
+++ b/m3/reporter_benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkCalulateSize(b *testing.B) {
 	benchReporter := r.(*reporter)
 
 	val := int64(123456)
-	met := benchReporter.newMetric("foo", nil, counterType)
+	met := benchReporter.newMetric("foo", map[string]string{"domain": "foo"}, counterType)
 	met.MetricValue.Count.I64Value = &val
 
 	b.ResetTimer()


### PR DESCRIPTION
calculateSize uses a custom TTransport to count the number of
bytes without moving bytes around. However, since it's not a
TRichTransport, when used with TCompactProtocol, string field
writes cast to `[]byte`, and use the `Write` method.

By modifying TCalcTransport to implement TRichTransport, we can
avoid these allocations and speed up the calculation.

BenchmarkCalulateSize (no tags) comparison:
```
benchmark                    old ns/op     new ns/op     delta
BenchmarkCalulateSize-12     547           324           -40.77%

benchmark                    old allocs     new allocs     delta
BenchmarkCalulateSize-12     9              0              -100.00%

benchmark                    old bytes     new bytes     delta
BenchmarkCalulateSize-12     16            0             -100.00%
```

BenchmarkCalulateSize (1 tag) comparison:
```
benchmark                    old ns/op     new ns/op     delta
BenchmarkCalulateSize-12     1098          561           -48.91%

benchmark                    old allocs     new allocs     delta
BenchmarkCalulateSize-12     16             0              -100.00%

benchmark                    old bytes     new bytes     delta
BenchmarkCalulateSize-12     56            0             -100.00%
```

See internal task T4903325 for more details.