### PR TITLE
m3: Remove atomic from TCalcTransport

### DIFF
--- a/m3/customtransports/m3_calc_transport.go
+++ b/m3/customtransports/m3_calc_transport.go
@@ -21,7 +21,7 @@
 package customtransport
 
 // TCalcTransport is a thrift TTransport that is used to calculate how many
-// bytes are used when writing a thrift element. It is thread-safe
+// bytes are used when writing a thrift element.
 type TCalcTransport struct {
 	count int32
 }

--- a/m3/customtransports/m3_calc_transport.go
+++ b/m3/customtransports/m3_calc_transport.go
@@ -20,10 +20,6 @@
 
 package customtransport
 
-import (
-	"sync/atomic"
-)
-
 // TCalcTransport is a thrift TTransport that is used to calculate how many
 // bytes are used when writing a thrift element. It is thread-safe
 type TCalcTransport struct {
@@ -33,32 +29,32 @@ type TCalcTransport struct {
 // GetCount returns the number of bytes that would be written
 // Required to maintain thrift.TTransport interface
 func (p *TCalcTransport) GetCount() int32 {
-	return atomic.LoadInt32(&p.count)
+	return p.count
 }
 
 // ResetCount resets the number of bytes written to 0
 func (p *TCalcTransport) ResetCount() {
-	atomic.StoreInt32(&p.count, 0)
+	p.count = 0
 }
 
 // Write adds the number of bytes written to the count
 // Required to maintain thrift.TTransport interface
 func (p *TCalcTransport) Write(buf []byte) (int, error) {
-	atomic.AddInt32(&p.count, int32(len(buf)))
+	p.count += int32(len(buf))
 	return len(buf), nil
 }
 
 // WriteByte adds 1 to the count
 // Required to maintain thrift.TRichTransport interface
 func (p *TCalcTransport) WriteByte(byte) error {
-	atomic.AddInt32(&p.count, 1)
+	p.count++
 	return nil
 }
 
 // WriteString adds the length of the string to the count
 // Required to maintain thrift.TRichTransport interface
 func (p *TCalcTransport) WriteString(s string) (int, error) {
-	atomic.AddInt32(&p.count, int32(len(s)))
+	p.count += int32(len(s))
 	return len(s), nil
 }
 


### PR DESCRIPTION
The TCalcTransport is used by a single caller at a time, with a
mutex used to protect access:
https://github.com/uber-go/tally/blob/5431c04afc0bad76ce91ca3d549abb469abd2a10/m3/reporter.go#L400

The thrift generated code will only call `Write` serially, so there's no
need to use atomics here.

Removal of atomics gives a small performance improvement (10-15%):
```
> benchcmp -best old new
benchmark                 old ns/op     new ns/op     delta
BenchmarkCalulateSize     538           453           -15.80%
```