### PR TITLE
Optimize Scope.cacheReport

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultInitialSliceSize = 16
+	_defaultInitialSliceSize = 16
 )
 
 var (
@@ -79,10 +79,11 @@ type scope struct {
 	countersSlice   []*counter
 	gauges          map[string]*gauge
 	gaugesSlice     []*gauge
-	timers          map[string]*timer
-	timersSlice     []*timer
 	histograms      map[string]*histogram
 	histogramsSlice []*histogram
+	timers          map[string]*timer
+	// nb: deliberately skipping timersSlice as we report timers immediately,
+	// no buffering is involved.
 }
 
 type scopeStatus struct {
@@ -169,13 +170,12 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 		},
 
 		counters:        make(map[string]*counter),
-		countersSlice:   make([]*counter, 0, defaultInitialSliceSize),
+		countersSlice:   make([]*counter, 0, _defaultInitialSliceSize),
 		gauges:          make(map[string]*gauge),
-		gaugesSlice:     make([]*gauge, 0, defaultInitialSliceSize),
-		timers:          make(map[string]*timer),
-		timersSlice:     make([]*timer, 0, defaultInitialSliceSize),
+		gaugesSlice:     make([]*gauge, 0, _defaultInitialSliceSize),
 		histograms:      make(map[string]*histogram),
-		histogramsSlice: make([]*histogram, 0, defaultInitialSliceSize),
+		histogramsSlice: make([]*histogram, 0, _defaultInitialSliceSize),
+		timers:          make(map[string]*timer),
 	}
 
 	// NB(r): Take a copy of the tags on creation
@@ -378,7 +378,6 @@ func (s *scope) Timer(name string) Timer {
 		s.fullyQualifiedName(name), s.tags, s.reporter, cachedTimer,
 	)
 	s.timers[name] = t
-	s.timersSlice = append(s.timersSlice, t)
 
 	return t
 }
@@ -479,13 +478,12 @@ func (s *scope) subscope(prefix string, immutableTags map[string]string) Scope {
 		registry:       s.registry,
 
 		counters:        make(map[string]*counter),
-		countersSlice:   make([]*counter, 0, defaultInitialSliceSize),
+		countersSlice:   make([]*counter, 0, _defaultInitialSliceSize),
 		gauges:          make(map[string]*gauge),
-		gaugesSlice:     make([]*gauge, 0, defaultInitialSliceSize),
-		timers:          make(map[string]*timer),
-		timersSlice:     make([]*timer, 0, defaultInitialSliceSize),
+		gaugesSlice:     make([]*gauge, 0, _defaultInitialSliceSize),
 		histograms:      make(map[string]*histogram),
-		histogramsSlice: make([]*histogram, 0, defaultInitialSliceSize),
+		histogramsSlice: make([]*histogram, 0, _defaultInitialSliceSize),
+		timers:          make(map[string]*timer),
 	}
 
 	s.registry.subscopes[key] = subscope

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func BenchmarkNameGeneration(b *testing.B) {
@@ -120,4 +121,83 @@ func BenchmarkHistogramExisting(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		root.Histogram("foo", DefaultBuckets)
 	}
+}
+
+func benchmarkScopeReportingN(b *testing.B, numElems int) {
+	root, _ := NewRootScope(ScopeOptions{
+		Prefix:          "funkytown",
+		CachedReporter:  noopCachedReporter{},
+		SanitizeOptions: &alphanumericSanitizerOpts,
+	}, 0)
+	s := root.(*scope)
+
+	ids := make([]string, 0, numElems)
+	for i := 0; i < numElems; i++ {
+		id := fmt.Sprintf("take.me.to.%d", i)
+		ids = append(ids, id)
+		s.Counter(id)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		s.cachedReport()
+	}
+}
+
+func BenchmarkScopeReporting(b *testing.B) {
+	for i := 1; i <= 10000000; i *= 10 {
+		size := fmt.Sprintf("size%d", i)
+		b.Run(size, func(b *testing.B) {
+			benchmarkScopeReportingN(b, i)
+		})
+	}
+}
+
+type noopStat struct{}
+
+func (s noopStat) ReportCount(value int64)            {}
+func (s noopStat) ReportGauge(value float64)          {}
+func (s noopStat) ReportTimer(interval time.Duration) {}
+func (s noopStat) ValueBucket(bucketLowerBound, bucketUpperBound float64) CachedHistogramBucket {
+	return s
+}
+func (s noopStat) DurationBucket(bucketLowerBound, bucketUpperBound time.Duration) CachedHistogramBucket {
+	return s
+}
+func (s noopStat) ReportSamples(value int64) {}
+
+type noopCachedReporter struct{}
+
+func (n noopCachedReporter) Capabilities() Capabilities {
+	return n
+}
+
+func (n noopCachedReporter) Reporting() bool { return true }
+func (n noopCachedReporter) Tagging() bool   { return true }
+func (n noopCachedReporter) Flush()          {}
+
+func (n noopCachedReporter) ReportCounter(name string, tags map[string]string, value int64) {}
+func (n noopCachedReporter) ReportGauge(name string, tags map[string]string, value float64) {}
+
+func (n noopCachedReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+}
+
+func (n noopCachedReporter) ReportHistogramValueSamples(name string, tags map[string]string, buckets Buckets, bucketLowerBound float64, bucketUpperBound float64, samples int64) {
+}
+func (n noopCachedReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets Buckets, bucketLowerBound time.Duration, bucketUpperBound time.Duration, samples int64) {
+}
+
+func (n noopCachedReporter) AllocateCounter(name string, tags map[string]string) CachedCount {
+	return noopStat{}
+}
+
+func (n noopCachedReporter) AllocateGauge(name string, tags map[string]string) CachedGauge {
+	return noopStat{}
+}
+
+func (n noopCachedReporter) AllocateTimer(name string, tags map[string]string) CachedTimer {
+	return noopStat{}
+}
+func (n noopCachedReporter) AllocateHistogram(name string, tags map[string]string, buckets Buckets) CachedHistogram {
+	return noopStat{}
 }

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -145,7 +145,7 @@ func benchmarkScopeReportingN(b *testing.B, numElems int) {
 }
 
 func BenchmarkScopeReporting(b *testing.B) {
-	for i := 1; i <= 10000000; i *= 10 {
+	for i := 1; i <= 1000000; i *= 10 {
 		size := fmt.Sprintf("size%d", i)
 		b.Run(size, func(b *testing.B) {
 			benchmarkScopeReportingN(b, i)


### PR DESCRIPTION
Optimize the cacheReport path for all Scopes.

Results for the added benchmark (master v HEAD):
```
benchmark                                  old ns/op      new ns/op     delta
BenchmarkScopeReporting/size1-4            79.6           42.0          -47.24%
BenchmarkScopeReporting/size10-4           201            62.3          -69.00%
BenchmarkScopeReporting/size100-4          1666           282           -83.07%
BenchmarkScopeReporting/size1000-4         16439          2547          -84.51%
BenchmarkScopeReporting/size10000-4        167362         26812         -83.98%
BenchmarkScopeReporting/size100000-4       4239618        328205        -92.26%
BenchmarkScopeReporting/size1000000-4      69189550       5549203       -91.98%
BenchmarkScopeReporting/size10000000-4     2205450363     35460112      -98.39%
```

Map iteration << Slice iteration