### PR TITLE
subscoping: Defer tag merging

### DIFF
--- a/key_gen_test.go
+++ b/key_gen_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyForPrefixedStringMaps(t *testing.T) {
+	tests := []struct {
+		desc   string
+		prefix string
+		maps   []map[string]string
+		want   string
+	}{
+		{
+			desc:   "no maps",
+			prefix: "foo",
+			want:   "foo+",
+		},
+		{
+			desc:   "disjoint maps",
+			prefix: "foo",
+			maps: []map[string]string{
+				{
+					"a": "foo",
+					"b": "bar",
+				},
+				{
+					"c": "baz",
+					"d": "qux",
+				},
+			},
+			want: "foo+a=foo,b=bar,c=baz,d=qux",
+		},
+		{
+			desc:   "map overlap",
+			prefix: "foo",
+			maps: []map[string]string{
+				{
+					"a": "1",
+					"b": "1",
+					"c": "1",
+					"d": "1",
+				},
+				{"b": "2"},
+				{"c": "3"},
+				{"d": "4"},
+			},
+			want: "foo+a=1,b=2,c=3,d=4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := keyForPrefixedStringMaps(tt.prefix, tt.maps...)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -91,6 +91,54 @@ func BenchmarkNameGenerationTagged(b *testing.B) {
 	}
 }
 
+func BenchmarkScopeTaggedCachedSubscopes(b *testing.B) {
+	root, _ := NewRootScope(ScopeOptions{
+		Prefix:   "funkytown",
+		Reporter: NullStatsReporter,
+		Tags: map[string]string{
+			"style":     "funky",
+			"hair":      "wavy",
+			"jefferson": "starship",
+		},
+	}, 0)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		root.Tagged(map[string]string{
+			"foo": "bar",
+			"baz": "qux",
+			"qux": "quux",
+		})
+	}
+}
+
+func BenchmarkScopeTaggedNoCachedSubscopes(b *testing.B) {
+	root, _ := NewRootScope(ScopeOptions{
+		Prefix:   "funkytown",
+		Reporter: NullStatsReporter,
+		Tags: map[string]string{
+			"style":     "funky",
+			"hair":      "wavy",
+			"jefferson": "starship",
+		},
+	}, 0)
+
+	values := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		values[i] = strconv.Itoa(i)
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		root.Tagged(map[string]string{
+			"foo": values[n],
+			"baz": values[n],
+			"qux": values[n],
+		})
+	}
+}
+
 func BenchmarkNameGenerationNoPrefix(b *testing.B) {
 	root, _ := NewRootScope(ScopeOptions{
 		Reporter: NullStatsReporter,

--- a/scope_registry.go
+++ b/scope_registry.go
@@ -1,8 +1,28 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package tally
 
 import "sync"
 
-var scopeRegistryKey = KeyForPrefixedStringMap
+var scopeRegistryKey = keyForPrefixedStringMaps
 
 type scopeRegistry struct {
 	mu        sync.RWMutex
@@ -45,8 +65,7 @@ func (r *scopeRegistry) ForEachScope(f func(*scope)) {
 }
 
 func (r *scopeRegistry) Subscope(parent *scope, prefix string, tags map[string]string) *scope {
-	allTags := mergeRightTags(parent.tags, tags)
-	key := scopeRegistryKey(prefix, allTags)
+	key := scopeRegistryKey(prefix, parent.tags, tags)
 
 	r.mu.RLock()
 	if s, ok := r.lockedLookup(key); ok {
@@ -62,6 +81,7 @@ func (r *scopeRegistry) Subscope(parent *scope, prefix string, tags map[string]s
 		return s
 	}
 
+	allTags := mergeRightTags(parent.tags, tags)
 	subscope := &scope{
 		separator: parent.separator,
 		prefix:    prefix,

--- a/scope_registry.go
+++ b/scope_registry.go
@@ -1,0 +1,93 @@
+package tally
+
+import "sync"
+
+var scopeRegistryKey = KeyForPrefixedStringMap
+
+type scopeRegistry struct {
+	mu        sync.RWMutex
+	subscopes map[string]*scope
+}
+
+func newScopeRegistry(root *scope) *scopeRegistry {
+	r := &scopeRegistry{
+		subscopes: make(map[string]*scope),
+	}
+	r.subscopes[scopeRegistryKey(root.prefix, root.tags)] = root
+	return r
+}
+
+func (r *scopeRegistry) Report(reporter StatsReporter) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.subscopes {
+		s.report(reporter)
+	}
+}
+
+func (r *scopeRegistry) CachedReport() {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.subscopes {
+		s.cachedReport()
+	}
+}
+
+func (r *scopeRegistry) ForEachScope(f func(*scope)) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.subscopes {
+		f(s)
+	}
+}
+
+func (r *scopeRegistry) Subscope(parent *scope, prefix string, tags map[string]string) *scope {
+	allTags := mergeRightTags(parent.tags, tags)
+	key := scopeRegistryKey(prefix, allTags)
+
+	r.mu.RLock()
+	if s, ok := r.lockedLookup(key); ok {
+		r.mu.RUnlock()
+		return s
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if s, ok := r.lockedLookup(key); ok {
+		return s
+	}
+
+	subscope := &scope{
+		separator: parent.separator,
+		prefix:    prefix,
+		// NB(prateek): don't need to copy the tags here,
+		// we assume the map provided is immutable.
+		tags:           allTags,
+		reporter:       parent.reporter,
+		cachedReporter: parent.cachedReporter,
+		baseReporter:   parent.baseReporter,
+		defaultBuckets: parent.defaultBuckets,
+		sanitizer:      parent.sanitizer,
+		registry:       parent.registry,
+
+		counters:        make(map[string]*counter),
+		countersSlice:   make([]*counter, 0, _defaultInitialSliceSize),
+		gauges:          make(map[string]*gauge),
+		gaugesSlice:     make([]*gauge, 0, _defaultInitialSliceSize),
+		histograms:      make(map[string]*histogram),
+		histogramsSlice: make([]*histogram, 0, _defaultInitialSliceSize),
+		timers:          make(map[string]*timer),
+	}
+	r.subscopes[key] = subscope
+	return subscope
+}
+
+func (r *scopeRegistry) lockedLookup(key string) (*scope, bool) {
+	ss, ok := r.subscopes[key]
+	return ss, ok
+}


### PR DESCRIPTION
**Commits should be reviewed individually.**

This improves the performance of creating subscopes with new tags by
deferring merged map creation.

We currently create the merged map of tags first, and then calculate the
key which we use to determine if we have a cached subscope.

With this change, we calculate the key with slightly more complex logic
that inspects the unmerged maps and avoids paying the cost of merging
the maps if not needed.

To make this change, we first refactor scopeRegistry so that Scope
accesses it like a separate object.

---

I ran the benchmarks with `-count 3`.

**Before**

```
BenchmarkScopeTaggedCachedSubscopes-4             486406              2334 ns/op            1152 B/op          9 allocs/op
BenchmarkScopeTaggedCachedSubscopes-4             445890              2567 ns/op            1152 B/op          9 allocs/op
BenchmarkScopeTaggedCachedSubscopes-4             423003              2721 ns/op            1152 B/op          9 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           189488              6149 ns/op            2203 B/op         17 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           273436              6063 ns/op            2235 B/op         17 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           278360              5049 ns/op            2233 B/op         17 allocs/op
```

**After**

```
BenchmarkScopeTaggedCachedSubscopes-4             652670              1791 ns/op             832 B/op          8 allocs/op
BenchmarkScopeTaggedCachedSubscopes-4             669008              1953 ns/op             832 B/op          8 allocs/op
BenchmarkScopeTaggedCachedSubscopes-4             591230              1817 ns/op             832 B/op          8 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           234835              5876 ns/op            2269 B/op         18 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           315829              5058 ns/op            2237 B/op         18 allocs/op
BenchmarkScopeTaggedNoCachedSubscopes-4           243750              4993 ns/op            2264 B/op         18 allocs/op
```

On average,

- Cached hits are ~27% *faster*: ~687 ns/op
- Cache misses are ~7% *faster*: ~444 ns/op