### PR TITLE
Allow Prometheus reporter listen on unix domain socket address

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -153,20 +153,20 @@ func (c Configuration) NewReporter(
 		mux := http.NewServeMux()
 		mux.Handle(path, reporter.HTTPHandler())
 		go func() {
-			nwk := c.ListenNetwork
-			if nwk == "" {
-				nwk = "tcp"
+			network := c.ListenNetwork
+			if network == "" {
+				network = "tcp"
 			}
 
-			lsn, err := net.Listen(nwk, addr)
+			listener, err := net.Listen(network, addr)
 			if err != nil {
 				opts.OnRegisterError(err)
 				return
 			}
 
-			defer lsn.Close()
+			defer listener.Close()
 
-			if err = http.Serve(lsn, mux); err != nil {
+			if err = http.Serve(listener, mux); err != nil {
 				opts.OnRegisterError(err)
 			}
 		}()

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -68,11 +68,8 @@ func TestUnixDomainSocketListener(t *testing.T) {
 func TestTcpListener(t *testing.T) {
 	cases := map[string]Configuration{
 		"127.0.0.1:0":        {ListenAddress: "127.0.0.1:0"},
-		"[::1]:0":            {ListenAddress: "[::1]:0"},
 		"tcp://127.0.0.1:0":  {ListenNetwork: "tcp", ListenAddress: "127.0.0.1:0"},
-		"tcp://[::1]:0":      {ListenNetwork: "tcp", ListenAddress: "[::1]:0"},
 		"tcp4://127.0.0.1:0": {ListenNetwork: "tcp4", ListenAddress: "127.0.0.1:0"},
-		"tcp6://[::1]:0":     {ListenNetwork: "tcp6", ListenAddress: "[::1]:0"},
 	}
 
 	for cn, cc := range cases {

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -21,7 +21,6 @@
 package prometheus
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -57,16 +56,31 @@ func TestUnixDomainSocketListener(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	uds := path.Join(dir, "test-metrics.sock")
-	cfg := Configuration{
-		ListenAddress: fmt.Sprintf("unix://%s", uds),
-		OnError:       "log",
-	}
-
-	go func() {
-		_, _ = cfg.NewReporter(ConfigurationOptions{})
-	}()
+	cfg := Configuration{ListenNetwork: "unix", ListenAddress: uds}
+	_, _ = cfg.NewReporter(ConfigurationOptions{})
 
 	time.Sleep(time.Second)
 	_, err = os.Stat(uds)
 	require.NoError(t, err)
+	require.NoError(t, os.Remove(uds))
+}
+
+func TestTcpListener(t *testing.T) {
+	cases := map[string]Configuration{
+		"127.0.0.1:0":        {ListenAddress: "127.0.0.1:0"},
+		"[::1]:0":            {ListenAddress: "[::1]:0"},
+		"tcp://127.0.0.1:0":  {ListenNetwork: "tcp", ListenAddress: "127.0.0.1:0"},
+		"tcp://[::1]:0":      {ListenNetwork: "tcp", ListenAddress: "[::1]:0"},
+		"tcp4://127.0.0.1:0": {ListenNetwork: "tcp4", ListenAddress: "127.0.0.1:0"},
+		"tcp6://[::1]:0":     {ListenNetwork: "tcp6", ListenAddress: "[::1]:0"},
+	}
+
+	for cn, cc := range cases {
+		t.Run(cn, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_, _ = cc.NewReporter(ConfigurationOptions{})
+				time.Sleep(time.Second)
+			})
+		})
+	}
 }


### PR DESCRIPTION
This PR will allow prometheus reporter listen on unix domain socket address. This is very useful when running under a situation when port conflicts occur often.

Currently, if specify a UDS address like `unix:/tmp/tally-metrics.sock` as listening address, reporter would fail to start as `http.ListenAndServe()` used by the reporter only support `tcp` network.