### PR TITLE
Removing m3db forked packages

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"strings"
 
-	prom "github.com/m3db/prometheus_client_golang/prometheus"
+	prom "github.com/prometheus/client_golang/prometheus"
 )
 
 // Configuration is a configuration for a Prometheus reporter.

--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
-	prom "github.com/m3db/prometheus_client_golang/prometheus"
-	"github.com/m3db/prometheus_client_golang/prometheus/promhttp"
 	"github.com/pkg/errors"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/uber-go/tally"
 )
 
@@ -163,8 +163,8 @@ type cachedMetric struct {
 	counter     prom.Counter
 	gauge       prom.Gauge
 	reportTimer func(d time.Duration)
-	histogram   prom.Histogram
-	summary     prom.Summary
+	histogram   prom.Observer
+	summary     prom.Observer
 }
 
 func (m *cachedMetric) ReportCount(value int64) {

--- a/prometheus/reporter_test.go
+++ b/prometheus/reporter_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	prom "github.com/m3db/prometheus_client_golang/prometheus"
-	dto "github.com/m3db/prometheus_client_model/go"
+	prom "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/uber-go/tally"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Tally is using bunch of m3db forked packages. These forks don't provide any use and they prevent from using the rest of the Prometheus library in conjunction with tally. 
For ex I should be able to do this:
```
 reg := prometheus.NewRegistry()
grpcMetrics := grpc_prometheus.NewServerMetrics()
reg.MustRegister(grpcMetrics)
var registerer prometheus.Registerer = reg
r := promreporter.NewReporter(promreporter.Options{
  Registerer: reg,
})
```