### PR TITLE
Make histogram allocations more efficient, general cleanup

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 6c5a37d4f995175d7ab310d09b5866057c683536b0ae3d8f478f87943aa03be4
-updated: 2019-11-07T15:02:21.080076-05:00
+updated: 2021-02-05T09:45:14.308188-05:00
 imports:
 - name: github.com/beorn7/perks
-  version: 3a771d992973f24aa725d07868b467d1ddfceafb
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - statsd
 - name: github.com/golang/protobuf
-  version: 14aad3d5ea4c323bcd7a2137e735da24a76e814c
+  version: 6c65a5562fc06764971b7c5d05c76c75e84bdbf7
   subpackages:
   - proto
 - name: github.com/m3db/prometheus_client_golang
@@ -35,13 +35,15 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/pkg/errors
-  version: ba968bfe8b2f7e042a574c888954fccecfa385b4
+  version: 614d223910a179a466c1767a985424175c39b465
+- name: github.com/pkg/profile
+  version: 5b67d428864e92711fcbd2f8629456121a56d91f
 - name: go.uber.org/atomic
-  version: 9dc4df04d0d1c39369750a9f6c32c39560672089
+  version: 12f27ba2637fa0e13772a4f05fa46a5d18d53182
 - name: gopkg.in/validator.v2
-  version: 135c24b11c19e52befcae2ec3fca5d9b78c4e98e
+  version: 2b28d334fa054977b7c725c7639a1ca4efc18bad
 - name: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  version: 7649d4548cb53a614db133b2a8ac1f31859dda8c
 testImports:
 - name: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b

--- a/m3/customtransports/buffered_read_transport_test.go
+++ b/m3/customtransports/buffered_read_transport_test.go
@@ -45,6 +45,7 @@ func TestTBufferedReadTransport(t *testing.T) {
 	secondRead := make([]byte, 7)
 	n, err = trans.Read(secondRead)
 	require.Equal(t, 6, n)
+	require.NoError(t, err)
 	require.Equal(t, []byte("String"), secondRead[0:6])
 	require.Equal(t, uint64(0), trans.RemainingBytes())
 }

--- a/m3/example/local_server.go
+++ b/m3/example/local_server.go
@@ -86,7 +86,10 @@ func (f *localM3Server) Serve() error {
 		} else {
 			proto = thrift.NewTBinaryProtocolTransport(trans)
 		}
-		f.processor.Process(proto, proto)
+
+		if _, err = f.processor.Process(proto, proto); err != nil {
+			fmt.Println("Error processing thrift metric:", err)
+		}
 	}
 }
 

--- a/m3/reporter_benchmark_test.go
+++ b/m3/reporter_benchmark_test.go
@@ -28,16 +28,6 @@ import (
 	"github.com/uber-go/tally"
 )
 
-const (
-	updaters = 10
-	updates  = 1000
-	numIds   = 10
-
-	testID = "stats.$dc.gauges.m3+" +
-		"servers.my-internal-server-$dc.network.eth0_tx_colls+" +
-		"dc=$dc,domain=production.$zone,env=production,pipe=$pipe,service=servers,type=gauge"
-)
-
 func BenchmarkNewMetric(b *testing.B) {
 	r, _ := NewReporter(Options{
 		HostPorts:  []string{"127.0.0.1:9052"},

--- a/m3/reporter_test.go
+++ b/m3/reporter_test.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	numReaders    = 10
 	queueSize     = 1000
 	includeHost   = true
 	maxPacketSize = int32(1440)
@@ -628,7 +627,13 @@ func (f *fakeM3Server) Serve() {
 		} else {
 			proto = thrift.NewTBinaryProtocolTransport(trans)
 		}
-		f.processor.Process(proto, proto)
+
+		_, err = f.processor.Process(proto, proto)
+		if terr, ok := err.(thrift.TTransportException); ok {
+			require.Equal(f.t, thrift.END_OF_FILE, terr.TypeId())
+		} else {
+			require.NoError(f.t, err)
+		}
 	}
 }
 

--- a/m3/resource_pool.go
+++ b/m3/resource_pool.go
@@ -146,6 +146,7 @@ func (r *resourcePool) getProto() thrift.TProtocol {
 	return o.(thrift.TProtocol)
 }
 
+//nolint:unused
 func (r *resourcePool) releaseProto(proto thrift.TProtocol) {
 	calc := proto.Transport().(*customtransport.TCalcTransport)
 	calc.ResetCount()
@@ -180,6 +181,7 @@ func (r *resourcePool) releaseMetricValue(metVal *m3thrift.MetricValue) {
 	r.valuePool.Put(metVal)
 }
 
+//nolint:unused
 func (r *resourcePool) releaseMetrics(mets []*m3thrift.Metric) {
 	for _, m := range mets {
 		r.releaseMetric(m)

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -231,6 +231,7 @@ func BenchmarkScopeReportHistogram(b *testing.B) {
 	}
 
 	histogram := perEndpointScope.Histogram("inbound.latency", buckets)
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	bucketsLen := len(buckets)

--- a/m3/thriftudp/transport_test.go
+++ b/m3/thriftudp/transport_test.go
@@ -278,8 +278,10 @@ func TestFlushErrors(t *testing.T) {
 		require.NoError(t, err)
 		trans.conn.Close()
 
-		trans.Write([]byte{1, 2, 3, 4})
-		err = trans.Flush()
+		_, err = trans.Write([]byte{1, 2, 3, 4})
+		require.NoError(t, err)
+
+		// err = trans.Flush()
 		require.Error(t, trans.Flush(), "Flush with data should fail")
 	})
 }
@@ -291,7 +293,9 @@ func TestResetInFlush(t *testing.T) {
 	trans, err := NewTUDPClientTransport(conn.LocalAddr().String(), "")
 	require.NoError(t, err)
 
-	trans.Write([]byte("some nonsense"))
+	_, err = trans.Write([]byte("some nonsense"))
+	require.NoError(t, err)
+
 	trans.conn.Close() // close the transport's connection via back door
 
 	err = trans.Flush()


### PR DESCRIPTION
Histogram types are mutually exclusive, so there's no need to allocate storage for both types regardless of which type of bucket is provided.

Also includes some miscellaneous tweaks/cleanup.

At 100k histograms, this reduces their memory footprint by 45-65%, with diminishing returns of ~2% every 100k thereafter.