### PR TITLE
Enable configurable TTL-based scope/metric deallocation

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -88,17 +88,26 @@ type CachedStatsReporter interface {
 		tags map[string]string,
 	) CachedCount
 
+	// DeallocateCounter deallocates a counter that is no longer needed.
+	DeallocateCounter(CachedCount)
+
 	// AllocateGauge pre allocates a gauge data structure with name & tags.
 	AllocateGauge(
 		name string,
 		tags map[string]string,
 	) CachedGauge
 
+	// DeallocateGauge deallocates a gauge that is no longer needed.
+	DeallocateGauge(CachedGauge)
+
 	// AllocateTimer pre allocates a timer data structure with name & tags.
 	AllocateTimer(
 		name string,
 		tags map[string]string,
 	) CachedTimer
+
+	// DeallocateTimer deallocates a timer that is no longer needed.
+	DeallocateTimer(CachedTimer)
 
 	// AllocateHistogram pre allocates a histogram data structure with name, tags,
 	// value buckets and duration buckets.
@@ -107,6 +116,9 @@ type CachedStatsReporter interface {
 		tags map[string]string,
 		buckets Buckets,
 	) CachedHistogram
+
+	// DeallocateHistogram deallocates a histogram that is no longer needed.
+	DeallocateHistogram(CachedHistogram)
 }
 
 // CachedCount interface for reporting an individual counter

--- a/scope.go
+++ b/scope.go
@@ -85,10 +85,11 @@ type scope struct {
 	histograms      map[string]*histogram
 	histogramsSlice []*histogram
 	timers          map[string]*timer
-	// nb: deliberately skipping timersSlice as we report timers immediately,
-	// no buffering is involved.
+	timersSlice     []*timer
 
 	bucketCache map[uint64]bucketStorage
+	lastReport  time.Time
+	root        bool
 }
 
 // n.b. This function is used to uniquely identify a given set of buckets
@@ -127,6 +128,18 @@ type ScopeOptions struct {
 	Separator       string
 	DefaultBuckets  Buckets
 	SanitizeOptions *SanitizeOptions
+
+	// UnusedScopeTTL configures scopes and the metrics they hold to be
+	// evicted from cache and deallocated if no metrics for a given scope have
+	// been reported within UnusedScopeTTL. Importantly, any pointers to scopes
+	// or metrics that are deallocated through this feature are invalidated.
+	// This setting does not affect root scopes.
+	UnusedScopeTTL time.Duration
+
+	// UnusedScopeDeepEviction controls whether unused scopes evicted from cache
+	// after UnusedScopeTTL has elapsed simply have their metrics deallocated
+	// (shallow) or both the metrics and the scope itself (deep).
+	UnusedScopeDeepEviction bool
 }
 
 // NewRootScope creates a new root Scope with a set of options and
@@ -179,6 +192,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 		baseReporter:   baseReporter,
 		defaultBuckets: opts.DefaultBuckets,
 		sanitizer:      sanitizer,
+		root:           true,
 		status: scopeStatus{
 			closed: false,
 			quit:   make(chan struct{}, 1),
@@ -191,6 +205,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 		histograms:      make(map[string]*histogram),
 		histogramsSlice: make([]*histogram, 0, _defaultInitialSliceSize),
 		timers:          make(map[string]*timer),
+		timersSlice:     make([]*timer, 0, _defaultInitialSliceSize),
 		bucketCache:     make(map[uint64]bucketStorage),
 	}
 
@@ -199,7 +214,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 	s.tags = s.copyAndSanitizeMap(opts.Tags)
 
 	// Register the root scope
-	s.registry = newScopeRegistry(s)
+	s.registry = newScopeRegistry(s, opts)
 
 	if interval > 0 {
 		go s.reportLoop(interval)
@@ -209,48 +224,78 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 }
 
 // report dumps all aggregated stats into the reporter. Should be called automatically by the root scope periodically.
-func (s *scope) report(r StatsReporter) {
+func (s *scope) report(r StatsReporter) (reported bool) {
 	s.cm.RLock()
 	for name, counter := range s.counters {
-		counter.report(s.fullyQualifiedName(name), s.tags, r)
+		if rep := counter.report(s.fullyQualifiedName(name), s.tags, r); rep {
+			reported = true
+		}
 	}
 	s.cm.RUnlock()
 
 	s.gm.RLock()
 	for name, gauge := range s.gauges {
-		gauge.report(s.fullyQualifiedName(name), s.tags, r)
+		if rep := gauge.report(s.fullyQualifiedName(name), s.tags, r); rep {
+			reported = true
+		}
 	}
 	s.gm.RUnlock()
 
 	// we do nothing for timers here because timers report directly to ths StatsReporter without buffering
+	s.tm.RLock()
+	for _, timer := range s.timersSlice {
+		if rep := timer.hasReported(); rep {
+			reported = true
+		}
+	}
+	s.tm.RUnlock()
 
 	s.hm.RLock()
 	for name, histogram := range s.histograms {
-		histogram.report(s.fullyQualifiedName(name), s.tags, r)
+		if rep := histogram.report(s.fullyQualifiedName(name), s.tags, r); rep {
+			reported = true
+		}
 	}
 	s.hm.RUnlock()
+
+	return
 }
 
-func (s *scope) cachedReport() {
+func (s *scope) cachedReport() (reported bool) {
 	s.cm.RLock()
 	for _, counter := range s.countersSlice {
-		counter.cachedReport()
+		if rep := counter.cachedReport(); rep {
+			reported = true
+		}
 	}
 	s.cm.RUnlock()
 
 	s.gm.RLock()
 	for _, gauge := range s.gaugesSlice {
-		gauge.cachedReport()
+		if rep := gauge.cachedReport(); rep {
+			reported = true
+		}
 	}
 	s.gm.RUnlock()
 
 	// we do nothing for timers here because timers report directly to ths StatsReporter without buffering
+	s.tm.RLock()
+	for _, timer := range s.timersSlice {
+		if rep := timer.hasReported(); rep {
+			reported = true
+		}
+	}
+	s.tm.RUnlock()
 
 	s.hm.RLock()
 	for _, histogram := range s.histogramsSlice {
-		histogram.cachedReport()
+		if rep := histogram.cachedReport(); rep {
+			reported = true
+		}
 	}
 	s.hm.RUnlock()
+
+	return
 }
 
 // reportLoop is used by the root scope for periodic reporting
@@ -387,6 +432,7 @@ func (s *scope) Timer(name string) Timer {
 		s.fullyQualifiedName(name), s.tags, s.reporter, cachedTimer,
 	)
 	s.timers[name] = t
+	s.timersSlice = append(s.timersSlice, t)
 
 	return t
 }
@@ -423,6 +469,7 @@ func (s *scope) Histogram(name string, b Buckets) Histogram {
 
 	var cachedHistogram CachedHistogram
 	if s.cachedReporter != nil {
+		// TODO: reuse common cached histogram storage
 		cachedHistogram = s.cachedReporter.AllocateHistogram(
 			s.fullyQualifiedName(name), s.tags, b,
 		)
@@ -576,6 +623,79 @@ func (s *scope) copyAndSanitizeMap(tags map[string]string) map[string]string {
 		result[k] = v
 	}
 	return result
+}
+
+func (s *scope) release() {
+	if s.root {
+		return
+	}
+
+	// Release all internal state. This invalidates any pointers held by users.
+	// As we're cleaning up, avoid doing work inside map loops so the compiler
+	// can optimize map clears; instead, do deallocs inside slice loops. This
+	// is effectively a scope-local STW, so lock everything at once: if we're
+	// calling this method, there's nothing left for this scope to do anyway.
+	//
+	// Since it's possible that there will be dangling pointers, delete all
+	// storage, not solely pooled storage.
+
+	s.cm.Lock()
+	defer s.cm.Unlock()
+	s.gm.Lock()
+	defer s.gm.Unlock()
+	s.tm.Lock()
+	defer s.tm.Unlock()
+	s.hm.Lock()
+	defer s.hm.Unlock()
+
+	for k := range s.counters {
+		delete(s.counters, k)
+	}
+	for i := range s.countersSlice {
+		s.cachedReporter.DeallocateCounter(s.countersSlice[i].cachedCount)
+		s.countersSlice[i].cachedCount = nil
+	}
+	s.countersSlice = s.countersSlice[:0]
+
+	for k := range s.gauges {
+		delete(s.gauges, k)
+	}
+	for i := range s.gaugesSlice {
+		s.cachedReporter.DeallocateGauge(s.gaugesSlice[i].cachedGauge)
+		s.gaugesSlice[i].cachedGauge = nil
+	}
+	s.gaugesSlice = s.gaugesSlice[:0]
+
+	for k := range s.timers {
+		delete(s.timers, k)
+	}
+	for i := range s.timersSlice {
+		s.cachedReporter.DeallocateTimer(s.timersSlice[i].cachedTimer)
+		s.timersSlice[i].cachedTimer = nil
+		for k := range s.timersSlice[i].tags {
+			delete(s.timersSlice[i].tags, k)
+		}
+		s.timersSlice[i].tags = nil
+	}
+	s.timersSlice = s.timersSlice[:0]
+
+	for k := range s.histograms {
+		delete(s.histograms, k)
+	}
+	for i := range s.histogramsSlice {
+		// n.b. We don't want to deallocate any shared storage, so instead just
+		//      deallocate bucket sample counters, which are unique to each
+		//      bucket within a given histogram instance.
+		for j := range s.histogramsSlice[i].samples {
+			s.cachedReporter.DeallocateCounter(s.histogramsSlice[i].samples[j].cachedCount)
+		}
+		s.histogramsSlice[i].samples = s.histogramsSlice[i].samples[:0]
+		for k := range s.histogramsSlice[i].tags {
+			delete(s.histogramsSlice[i].tags, k)
+		}
+		s.histogramsSlice[i].tags = nil
+	}
+	s.histogramsSlice = s.histogramsSlice[:0]
 }
 
 // TestScope is a metrics collector that has no reporting, ensuring that

--- a/scope.go
+++ b/scope.go
@@ -625,7 +625,7 @@ func (s *scope) copyAndSanitizeMap(tags map[string]string) map[string]string {
 	return result
 }
 
-func (s *scope) release() {
+func (s *scope) release(deep bool) {
 	if s.root {
 		return
 	}
@@ -696,6 +696,17 @@ func (s *scope) release() {
 		s.histogramsSlice[i].tags = nil
 	}
 	s.histogramsSlice = s.histogramsSlice[:0]
+
+	if deep {
+		s.counters = nil
+		s.countersSlice = nil
+		s.gauges = nil
+		s.gaugesSlice = nil
+		s.timers = nil
+		s.timersSlice = nil
+		s.histograms = nil
+		s.histogramsSlice = nil
+	}
 }
 
 // TestScope is a metrics collector that has no reporting, ensuring that

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -239,13 +239,22 @@ func (n noopCachedReporter) AllocateCounter(name string, tags map[string]string)
 	return noopStat{}
 }
 
+func (n noopCachedReporter) DeallocateCounter(CachedCount) {}
+
 func (n noopCachedReporter) AllocateGauge(name string, tags map[string]string) CachedGauge {
 	return noopStat{}
 }
 
+func (n noopCachedReporter) DeallocateGauge(CachedGauge) {}
+
 func (n noopCachedReporter) AllocateTimer(name string, tags map[string]string) CachedTimer {
 	return noopStat{}
 }
+
+func (n noopCachedReporter) DeallocateTimer(CachedTimer) {}
+
 func (n noopCachedReporter) AllocateHistogram(name string, tags map[string]string, buckets Buckets) CachedHistogram {
 	return noopStat{}
 }
+
+func (n noopCachedReporter) DeallocateHistogram(CachedHistogram) {}

--- a/scope_registry.go
+++ b/scope_registry.go
@@ -56,7 +56,7 @@ func (r *scopeRegistry) Report(reporter StatsReporter) {
 		}
 
 		if r.ttl > 0 && now.Sub(s.lastReport) > r.ttl {
-			s.release()
+			s.release(r.deep)
 
 			if r.deep {
 				delete(r.subscopes, key)
@@ -80,7 +80,7 @@ func (r *scopeRegistry) CachedReport() {
 		}
 
 		if r.ttl > 0 && now.Sub(s.lastReport) > r.ttl {
-			s.release()
+			s.release(r.deep)
 
 			if r.deep {
 				delete(r.subscopes, key)

--- a/scope_test.go
+++ b/scope_test.go
@@ -136,6 +136,8 @@ func (r *testStatsReporter) AllocateCounter(
 	return counter
 }
 
+func (r *testStatsReporter) DeallocateCounter(CachedCount) {}
+
 func (r *testStatsReporter) ReportCounter(name string, tags map[string]string, value int64) {
 	r.counters[name] = &testIntValue{
 		val:  value,
@@ -155,6 +157,8 @@ func (r *testStatsReporter) AllocateGauge(
 	r.gauges[name] = gauge
 	return gauge
 }
+
+func (r *testStatsReporter) DeallocateGauge(CachedGauge) {}
 
 func (r *testStatsReporter) ReportGauge(name string, tags map[string]string, value float64) {
 	r.gauges[name] = &testFloatValue{
@@ -176,6 +180,8 @@ func (r *testStatsReporter) AllocateTimer(
 	return timer
 }
 
+func (r *testStatsReporter) DeallocateTimer(CachedTimer) {}
+
 func (r *testStatsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
 	r.timers[name] = &testIntValue{
 		val:  int64(interval),
@@ -191,6 +197,8 @@ func (r *testStatsReporter) AllocateHistogram(
 ) CachedHistogram {
 	return testStatsReporterCachedHistogram{r, name, tags, buckets}
 }
+
+func (r *testStatsReporter) DeallocateHistogram(CachedHistogram) {}
 
 type testStatsReporterCachedHistogram struct {
 	r       *testStatsReporter

--- a/stats.go
+++ b/stats.go
@@ -81,22 +81,28 @@ func (c *counter) value() int64 {
 	return curr - prev
 }
 
-func (c *counter) report(name string, tags map[string]string, r StatsReporter) {
+func (c *counter) report(
+	name string,
+	tags map[string]string,
+	r StatsReporter,
+) bool {
 	delta := c.value()
 	if delta == 0 {
-		return
+		return false
 	}
 
 	r.ReportCounter(name, tags, delta)
+	return true
 }
 
-func (c *counter) cachedReport() {
+func (c *counter) cachedReport() bool {
 	delta := c.value()
 	if delta == 0 {
-		return
+		return false
 	}
 
 	c.cachedCount.ReportCount(delta)
+	return true
 }
 
 func (c *counter) snapshot() int64 {
@@ -122,16 +128,26 @@ func (g *gauge) value() float64 {
 	return math.Float64frombits(atomic.LoadUint64(&g.curr))
 }
 
-func (g *gauge) report(name string, tags map[string]string, r StatsReporter) {
-	if atomic.SwapUint64(&g.updated, 0) == 1 {
-		r.ReportGauge(name, tags, g.value())
+func (g *gauge) report(
+	name string,
+	tags map[string]string,
+	r StatsReporter,
+) bool {
+	if atomic.SwapUint64(&g.updated, 0) == 0 {
+		return false
 	}
+
+	r.ReportGauge(name, tags, g.value())
+	return true
 }
 
-func (g *gauge) cachedReport() {
-	if atomic.SwapUint64(&g.updated, 0) == 1 {
-		g.cachedGauge.ReportGauge(g.value())
+func (g *gauge) cachedReport() bool {
+	if atomic.SwapUint64(&g.updated, 0) == 0 {
+		return false
 	}
+
+	g.cachedGauge.ReportGauge(g.value())
+	return true
 }
 
 func (g *gauge) snapshot() float64 {
@@ -147,6 +163,7 @@ type timer struct {
 	reporter    StatsReporter
 	cachedTimer CachedTimer
 	unreported  timerValues
+	updated     uint32
 }
 
 type timerValues struct {
@@ -178,6 +195,8 @@ func (t *timer) Record(interval time.Duration) {
 	} else {
 		t.reporter.ReportTimer(t.name, t.tags, interval)
 	}
+
+	atomic.StoreUint32(&t.updated, 1)
 }
 
 func (t *timer) Start() Stopwatch {
@@ -187,6 +206,10 @@ func (t *timer) Start() Stopwatch {
 func (t *timer) RecordStopwatch(stopwatchStart time.Time) {
 	d := globalNow().Sub(stopwatchStart)
 	t.Record(d)
+}
+
+func (t *timer) hasReported() bool {
+	return atomic.SwapUint32(&t.updated, 0) == 1
 }
 
 func (t *timer) snapshot() []time.Duration {
@@ -300,12 +323,18 @@ func newHistogram( // need to be able to reuse internal histogram buckets and lo
 	return h
 }
 
-func (h *histogram) report(name string, tags map[string]string, r StatsReporter) {
+func (h *histogram) report(
+	name string,
+	tags map[string]string,
+	r StatsReporter,
+) (reported bool) {
 	for i := range h.buckets {
 		samples := h.samples[i].value()
 		if samples == 0 {
 			continue
 		}
+
+		reported = true
 
 		switch h.htype {
 		case valueHistogramType:
@@ -328,14 +357,18 @@ func (h *histogram) report(name string, tags map[string]string, r StatsReporter)
 			)
 		}
 	}
+
+	return
 }
 
-func (h *histogram) cachedReport() {
+func (h *histogram) cachedReport() (reported bool) {
 	for i := range h.buckets {
 		samples := h.samples[i].value()
 		if samples == 0 {
 			continue
 		}
+
+		reported = true
 
 		switch h.htype {
 		case valueHistogramType:
@@ -344,6 +377,8 @@ func (h *histogram) cachedReport() {
 			h.buckets[i].cachedDurationBucket.ReportSamples(samples)
 		}
 	}
+
+	return
 }
 
 func (h *histogram) RecordValue(value float64) {


### PR DESCRIPTION
Presently, scope and metric caches exist indefinitely. This creates a significant problem for applications dealing with a large number of metrics, particularly if the majority of metrics are emitted infrequently, or if dimensions are volatile (e.g. request-based metrics).

While this doesn't solve memory design issues within Tally, it at least affords the ability to configure if/when old memory should be reaped.