### PR TITLE
Share allocated tags among cached metrics

### DIFF
--- a/internal/cache/string_intern.go
+++ b/internal/cache/string_intern.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"sync"
+)
+
+// StringInterner interns strings.
+type StringInterner struct {
+	entries map[string]string
+	mtx     sync.RWMutex
+}
+
+// NewStringInterner creates a new StringInterner.
+func NewStringInterner() *StringInterner {
+	return &StringInterner{
+		entries: make(map[string]string),
+	}
+}
+
+// Intern interns s.
+func (i *StringInterner) Intern(s string) string {
+	i.mtx.RLock()
+	x, ok := i.entries[s]
+	i.mtx.RUnlock()
+
+	if ok {
+		return x
+	}
+
+	i.mtx.Lock()
+	i.entries[s] = s
+	i.mtx.Unlock()
+
+	return s
+}

--- a/internal/cache/tag_cache.go
+++ b/internal/cache/tag_cache.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/uber-go/tally/internal/identity"
+	m3thrift "github.com/uber-go/tally/m3/thrift/v2"
+)
+
+// TagCache is an identity.Accumulator-based tag cache.
+type TagCache struct {
+	entries map[uint64][]m3thrift.MetricTag
+	mtx     sync.RWMutex
+}
+
+// NewTagCache creates a new TagCache.
+func NewTagCache() *TagCache {
+	return &TagCache{
+		entries: make(map[uint64][]m3thrift.MetricTag),
+	}
+}
+
+// Get returns the cached value for key.
+func (c *TagCache) Get(key uint64) ([]m3thrift.MetricTag, bool) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	entry, ok := c.entries[key]
+	return entry, ok
+}
+
+// Set attempts to set the value of key as tslice, returning either tslice or
+// the pre-existing value if found.
+func (c *TagCache) Set(key uint64, tslice []m3thrift.MetricTag) []m3thrift.MetricTag {
+	c.mtx.RLock()
+	existing, ok := c.entries[key]
+	c.mtx.RUnlock()
+
+	if ok {
+		return existing
+	}
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.entries[key] = tslice
+	return tslice
+}
+
+// TagMapKey generates a new key based on tags.
+func TagMapKey(tags map[string]string) uint64 {
+	return identity.StringStringMap(tags)
+}

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/uber-go/tally"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,15 +57,8 @@ func newTestReporterScope(
 	}, shortInterval)
 
 	return r, scope, func() {
-		assert.NoError(t, closer.Close())
-
-		// Ensure reporter is closed too
-		r := r.(*reporter)
-		r.status.RLock()
-		closed := r.status.closed
-		r.status.RUnlock()
-
-		assert.True(t, closed)
+		require.NoError(t, closer.Close())
+		require.True(t, r.(*reporter).done.Load())
 	}
 }
 


### PR DESCRIPTION
This change:

1. Introduces string interning for allocated metrics, including names and tag keys/values
2. Shares tags among metrics where possible
3. Introduces tag caching
4. Reduces histogram bucket allocations by reporting using closures instead of heap-allocating the buckets themselves