### PR TITLE
Add internal experimental metrics to M3 reporter

### DIFF
--- a/m3/reporter_integration_test.go
+++ b/m3/reporter_integration_test.go
@@ -107,7 +107,7 @@ func testProcessFlushOnExit(t *testing.T, i int) {
 
 	require.Equal(t, 1, len(server.Service.getBatches()))
 	require.NotNil(t, server.Service.getBatches()[0])
-	require.Equal(t, 3, len(server.Service.getBatches()[0].GetMetrics()))
+	require.Equal(t, 8, len(server.Service.getBatches()[0].GetMetrics()))
 	metrics := server.Service.getBatches()[0].GetMetrics()
 	fmt.Printf("Test %d emitted:\n%v\n", i, metrics)
 }

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -72,12 +72,11 @@ func TestScope(t *testing.T) {
 	tags := map[string]string{"testTag": "TestValue", "testTag2": "TestValue2"}
 
 	_, scope, close := newTestReporterScope(t, server.Addr, "honk", tags)
-	defer close()
-
 	wg.Add(1)
 
 	timer := scope.Timer("dazzle")
 	timer.Start().Stop()
+	close()
 
 	wg.Wait()
 
@@ -85,7 +84,7 @@ func TestScope(t *testing.T) {
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 1, len(emittedTimers))
+	require.Equal(t, 6, len(emittedTimers))
 	require.Equal(t, "honk.dazzle", emittedTimers[0].GetName())
 }
 
@@ -99,20 +98,18 @@ func TestScopeCounter(t *testing.T) {
 	tags := map[string]string{"testTag": "TestValue", "testTag2": "TestValue2"}
 
 	_, scope, close := newTestReporterScope(t, server.Addr, "honk", tags)
-	defer close()
 
 	wg.Add(1)
-
 	counter := scope.Counter("foobar")
 	counter.Inc(42)
-
+	close()
 	wg.Wait()
 
 	require.Equal(t, 1, len(server.Service.getBatches()))
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 1, len(emittedTimers))
+	require.Equal(t, 6, len(emittedTimers))
 	require.Equal(t, "honk.foobar", emittedTimers[0].GetName())
 }
 
@@ -126,20 +123,18 @@ func TestScopeGauge(t *testing.T) {
 	tags := map[string]string{"testTag": "TestValue", "testTag2": "TestValue2"}
 
 	_, scope, close := newTestReporterScope(t, server.Addr, "honk", tags)
-	defer close()
 
 	wg.Add(1)
-
 	gauge := scope.Gauge("foobaz")
 	gauge.Update(42)
-
+	close()
 	wg.Wait()
 
 	require.Equal(t, 1, len(server.Service.getBatches()))
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 1, len(emittedTimers))
+	require.Equal(t, 6, len(emittedTimers))
 	require.Equal(t, "honk.foobaz", emittedTimers[0].GetName())
 }
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+// Version is the current version of the library.
+const Version = "3.4.0"


### PR DESCRIPTION
In addition to adding some useful internal tags, this also adds a Version constant (and tags the internal tags with it so that we can experiment with version tracking).