### PR TITLE
Do not drop reported metrics when flush channel is full

### DIFF
--- a/m3/reporter_integration_test.go
+++ b/m3/reporter_integration_test.go
@@ -107,7 +107,7 @@ func testProcessFlushOnExit(t *testing.T, i int) {
 
 	require.Equal(t, 1, len(server.Service.getBatches()))
 	require.NotNil(t, server.Service.getBatches()[0])
-	require.Equal(t, 8, len(server.Service.getBatches()[0].GetMetrics()))
+	require.Equal(t, 7, len(server.Service.getBatches()[0].GetMetrics()))
 	metrics := server.Service.getBatches()[0].GetMetrics()
 	fmt.Printf("Test %d emitted:\n%v\n", i, metrics)
 }

--- a/m3/reporter_test.go
+++ b/m3/reporter_test.go
@@ -114,9 +114,9 @@ func TestReporter(t *testing.T) {
 
 		// Validate metrics
 		emittedCounters := batches[0].GetMetrics()
-		require.Equal(t, 6, len(emittedCounters))
+		require.Equal(t, 5, len(emittedCounters))
 		emittedTimers := batches[1].GetMetrics()
-		require.Equal(t, 6, len(emittedTimers))
+		require.Equal(t, 5, len(emittedTimers))
 
 		emittedCounter, emittedTimer := emittedCounters[0], emittedTimers[0]
 		if emittedCounter.GetName() == "my-timer" {
@@ -510,13 +510,13 @@ func TestReporterResetTagsAfterReturnToPool(t *testing.T) {
 	c1 := r.AllocateCounter("counterWithTags", tags)
 
 	// Report the counter with tags to take the last slot.
-	wg.Add(6)
+	wg.Add(5)
 	c1.ReportCount(1)
 	r.Flush()
 	wg.Wait()
 
 	// Empty flush to ensure the copied metric is released.
-	wg.Add(5)
+	wg.Add(4)
 	r.Flush()
 	for {
 		rep := r.(*reporter)
@@ -531,7 +531,7 @@ func TestReporterResetTagsAfterReturnToPool(t *testing.T) {
 	c2 := r.AllocateCounter("counterWithNoTags", nil)
 
 	// Report the counter with no tags.
-	wg.Add(6)
+	wg.Add(5)
 	c2.ReportCount(1)
 	r.Flush()
 	wg.Wait()
@@ -539,7 +539,7 @@ func TestReporterResetTagsAfterReturnToPool(t *testing.T) {
 	// Verify that first reported counter has tags and the second
 	// reported counter has no tags.
 	metrics := server.Service.getMetrics()
-	require.Equal(t, 17, len(metrics)) // 2 test metrics, 5x3 internal metrics
+	require.Equal(t, 14, len(metrics)) // 2 test metrics, 4x3 internal metrics
 
 	var filtered []m3thrift.Metric
 	for _, metric := range metrics {

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -84,7 +84,7 @@ func TestScope(t *testing.T) {
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 6, len(emittedTimers))
+	require.Equal(t, 5, len(emittedTimers))
 	require.Equal(t, "honk.dazzle", emittedTimers[0].GetName())
 }
 
@@ -109,7 +109,7 @@ func TestScopeCounter(t *testing.T) {
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 6, len(emittedTimers))
+	require.Equal(t, 5, len(emittedTimers))
 	require.Equal(t, "honk.foobar", emittedTimers[0].GetName())
 }
 
@@ -134,7 +134,7 @@ func TestScopeGauge(t *testing.T) {
 	require.NotNil(t, server.Service.getBatches()[0])
 
 	emittedTimers := server.Service.getBatches()[0].GetMetrics()
-	require.Equal(t, 6, len(emittedTimers))
+	require.Equal(t, 5, len(emittedTimers))
 	require.Equal(t, "honk.foobaz", emittedTimers[0].GetName())
 }
 


### PR DESCRIPTION
Previously, if reporting a very large number of metrics, some metrics could be silently dropped. Instead, block under the assumption that current benchmarks (which put throughput at anywhere between 1-3M reported metrics/sec) exceed real world use cases for the number of metrics reported within a given report cycle (e.g. we will never report >1M metrics every 1s).