### PR TITLE
Add tag support in statsd reporter | Upgrade go-statsd-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,13 @@ import (
 )
 
 func newScope() (tally.Scope, io.Closer) {
-	statter, _ := statsd.NewBufferedClient("127.0.0.1:8125",
-		"stats", 100*time.Millisecond, 1440)
+	statter, err := statsd.NewClientWithConfig(&statsd.ClientConfig{
+		Address:       "127.0.0.1:8125",
+		Prefix:        "stats",
+		FlushInterval: 100 * time.Millisecond,
+		FlushBytes:    1440,
+		TagFormat:     statsd.InfixComma,
+	})
 
 	reporter := tallystatsd.NewReporter(statter, tallystatsd.Options{
 		SampleRate: 1.0,

--- a/glide.lock
+++ b/glide.lock
@@ -6,7 +6,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/cactus/go-statsd-client
-  version: 138b925ccdf617776955904ba7759fce64406cec
+  version: 7eb0950793aa9a679bc468eb1da9b5520f73b16f
   subpackages:
   - statsd
 - name: github.com/golang/protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/uber-go/tally
 import:
 - package: github.com/cactus/go-statsd-client
-  version: ~3.1.0
+  version: ^5.0.0
   subpackages:
   - statsd
 - package: github.com/m3db/prometheus_client_golang

--- a/statsd/reporter_test.go
+++ b/statsd/reporter_test.go
@@ -29,5 +29,17 @@ import (
 func TestCapabilities(t *testing.T) {
 	r := NewReporter(nil, Options{})
 	assert.True(t, r.Capabilities().Reporting())
-	assert.False(t, r.Capabilities().Tagging())
+	assert.True(t, r.Capabilities().Tagging())
+}
+
+func TestGetStatsdTagPairs(t *testing.T) {
+	tags := map[string]string{
+		"K1": "V1",
+		"K2": "V2",
+	}
+	tagPairs := getStatsdTagPairs(tags)
+	assert.Equal(t, "K1", tagPairs[0][0])
+	assert.Equal(t, "V1", tagPairs[0][1])
+	assert.Equal(t, "K2", tagPairs[1][0])
+	assert.Equal(t, "V2", tagPairs[1][1])
 }


### PR DESCRIPTION
Addresses #151 

## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Feature | Medium |

## Description
This PR adds / changes the following

- Upgrades `cactus-statsd-client` to `v5`
- Support tags in StatsD Reporter.
- Update README

## Motivation & Context
- Currently, Statsd reporter bundled within Tally doesn't support tags. Now that the statsd-client finally incorporates it https://github.com/cactus/go-statsd-client/issues/53, we should too.

## How was this tested?
- Master on Statsd Example Reporter
```
❯ nc 8125 -l -u                                                                                                            ▼
my-stats.my-service.test-counter:1
```

- This branch on Statsd Example Reporter with two tags `offset=-34.34` and `dev=local`
```
❯ nc 8125 -l -u                                                                                                            ▼
my-stats.my-service.test-counter,offset=-34.34,dev=local:2
```
![Pasted Graphic](https://user-images.githubusercontent.com/12872673/125498239-8b340e1b-3ceb-4248-820f-ae11339f0843.png)


## Bench stats
Here's  the benchstat between old (master) and new (this branch)

```
name                               old time/op    new time/op    delta
pkg:github.com/uber-go/tally/thirdparty/github.com/apache/thrift/lib/go/thrift goos:darwin goarch:amd64
BinaryBool_0-12                       161ns ± 0%     146ns ± 0%   ~     (p=1.000 n=1+1)
BinaryByte_0-12                       170ns ± 0%     172ns ± 0%   ~     (p=1.000 n=1+1)
BinaryI16_0-12                        320ns ± 0%     327ns ± 0%   ~     (p=1.000 n=1+1)
BinaryI32_0-12                        353ns ± 0%     351ns ± 0%   ~     (p=1.000 n=1+1)
BinaryI64_0-12                        491ns ± 0%     480ns ± 0%   ~     (p=1.000 n=1+1)
BinaryDouble_0-12                     553ns ± 0%     539ns ± 0%   ~     (p=1.000 n=1+1)
BinaryString_0-12                     683ns ± 0%     679ns ± 0%   ~     (p=1.000 n=1+1)
BinaryBinary_0-12                     222ns ± 0%     195ns ± 0%   ~     (p=1.000 n=1+1)
BinaryBool_1-12                       358ns ± 0%     302ns ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/uber-go/tally goos:darwin goarch:amd64
BucketsEqual/same_20_values-12       13.2ns ± 0%    12.7ns ± 0%   ~     (p=1.000 n=1+1)
BucketsEqual/same_20_durations-12    11.0ns ± 0%    10.5ns ± 0%   ~     (p=1.000 n=1+1)
NameGeneration-12                    22.1ns ± 0%    20.9ns ± 0%   ~     (p=1.000 n=1+1)
CounterAllocation-12                  576ns ± 0%     586ns ± 0%   ~     (p=1.000 n=1+1)
SanitizedCounterAllocation-12         620ns ± 0%     645ns ± 0%   ~     (p=1.000 n=1+1)
NameGenerationTagged-12              23.5ns ± 0%    21.9ns ± 0%   ~     (p=1.000 n=1+1)
ScopeTaggedCachedSubscopes-12        1.22µs ± 0%    1.24µs ± 0%   ~     (p=1.000 n=1+1)
ScopeTaggedNoCachedSubscopes-12      3.62µs ± 0%    3.65µs ± 0%   ~     (p=1.000 n=1+1)
NameGenerationNoPrefix-12            0.38ns ± 0%    0.38ns ± 0%   ~     (p=1.000 n=1+1)
HistogramAllocation-12               1.40µs ± 0%    1.48µs ± 0%   ~     (p=1.000 n=1+1)
HistogramExisting-12                 25.1ns ± 0%    24.2ns ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size1-12              35.0ns ± 0%    34.9ns ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size10-12             50.1ns ± 0%    49.3ns ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size100-12             204ns ± 0%     214ns ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size1000-12           1.89µs ± 0%    1.96µs ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size10000-12          19.4µs ± 0%    20.1µs ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size100000-12          205µs ± 0%     201µs ± 0%   ~     (p=1.000 n=1+1)
ScopeReporting/size1000000-12        3.38ms ± 0%    3.38ms ± 0%   ~     (p=1.000 n=1+1)
CounterInc-12                        4.51ns ± 0%    4.39ns ± 0%   ~     (p=1.000 n=1+1)
ReportCounterNoData-12               2.21ns ± 0%    2.21ns ± 0%   ~     (all equal)
ReportCounterWithData-12             15.3ns ± 0%    15.3ns ± 0%   ~     (p=1.000 n=1+1)
GaugeSet-12                          8.48ns ± 0%    8.58ns ± 0%   ~     (p=1.000 n=1+1)
ReportGaugeNoData-12                 7.11ns ± 0%    7.34ns ± 0%   ~     (p=1.000 n=1+1)
ReportGaugeWithData-12               18.0ns ± 0%    17.5ns ± 0%   ~     (p=1.000 n=1+1)
TimerStopwatch-12                     157ns ± 0%     152ns ± 0%   ~     (p=1.000 n=1+1)
TimerReport-12                        109ns ± 0%     105ns ± 0%   ~     (p=1.000 n=1+1)

name                               old alloc/op   new alloc/op   delta
pkg:github.com/uber-go/tally/thirdparty/github.com/apache/thrift/lib/go/thrift goos:darwin goarch:amd64
BinaryBool_0-12                       0.00B          0.00B        ~     (all equal)
BinaryByte_0-12                       0.00B          0.00B        ~     (all equal)
BinaryI16_0-12                        0.00B          0.00B        ~     (all equal)
BinaryI32_0-12                        0.00B          0.00B        ~     (all equal)
BinaryI64_0-12                        0.00B          0.00B        ~     (all equal)
BinaryDouble_0-12                     0.00B          0.00B        ~     (all equal)
BinaryString_0-12                      352B ± 0%      352B ± 0%   ~     (all equal)
BinaryBinary_0-12                      160B ± 0%      160B ± 0%   ~     (all equal)
BinaryBool_1-12                       0.00B          0.00B        ~     (all equal)
pkg:github.com/uber-go/tally goos:darwin goarch:amd64
BucketsEqual/same_20_values-12        0.00B          0.00B        ~     (all equal)
BucketsEqual/same_20_durations-12     0.00B          0.00B        ~     (all equal)
NameGeneration-12                     0.00B          0.00B        ~     (all equal)
CounterAllocation-12                   192B ± 0%      191B ± 0%   ~     (p=1.000 n=1+1)
SanitizedCounterAllocation-12          246B ± 0%      249B ± 0%   ~     (p=1.000 n=1+1)
NameGenerationTagged-12               0.00B          0.00B        ~     (all equal)
ScopeTaggedCachedSubscopes-12          816B ± 0%      816B ± 0%   ~     (all equal)
ScopeTaggedNoCachedSubscopes-12      2.35kB ± 0%    2.35kB ± 0%   ~     (p=1.000 n=1+1)
NameGenerationNoPrefix-12             0.00B          0.00B        ~     (all equal)
HistogramAllocation-12               1.20kB ± 0%    1.19kB ± 0%   ~     (p=1.000 n=1+1)
HistogramExisting-12                  0.00B          0.00B        ~     (all equal)
ScopeReporting/size1-12               0.00B          0.00B        ~     (all equal)
ScopeReporting/size10-12              0.00B          0.00B        ~     (all equal)
ScopeReporting/size100-12             0.00B          0.00B        ~     (all equal)
ScopeReporting/size1000-12            0.00B          0.00B        ~     (all equal)
ScopeReporting/size10000-12           0.00B          0.00B        ~     (all equal)
ScopeReporting/size100000-12          0.00B          0.00B        ~     (all equal)
ScopeReporting/size1000000-12         0.00B          0.00B        ~     (all equal)
CounterInc-12                         0.00B          0.00B        ~     (all equal)
ReportCounterNoData-12                0.00B          0.00B        ~     (all equal)
ReportCounterWithData-12              0.00B          0.00B        ~     (all equal)
GaugeSet-12                           0.00B          0.00B        ~     (all equal)
ReportGaugeNoData-12                  0.00B          0.00B        ~     (all equal)
ReportGaugeWithData-12                0.00B          0.00B        ~     (all equal)
TimerStopwatch-12                     0.00B          0.00B        ~     (all equal)
TimerReport-12                        0.00B          0.00B        ~     (all equal)

name                               old allocs/op  new allocs/op  delta
pkg:github.com/uber-go/tally/thirdparty/github.com/apache/thrift/lib/go/thrift goos:darwin goarch:amd64
BinaryBool_0-12                        0.00           0.00        ~     (all equal)
BinaryByte_0-12                        0.00           0.00        ~     (all equal)
BinaryI16_0-12                         0.00           0.00        ~     (all equal)
BinaryI32_0-12                         0.00           0.00        ~     (all equal)
BinaryI64_0-12                         0.00           0.00        ~     (all equal)
BinaryDouble_0-12                      0.00           0.00        ~     (all equal)
BinaryString_0-12                      7.00 ± 0%      7.00 ± 0%   ~     (all equal)
BinaryBinary_0-12                      1.00 ± 0%      1.00 ± 0%   ~     (all equal)
BinaryBool_1-12                        0.00           0.00        ~     (all equal)
pkg:github.com/uber-go/tally goos:darwin goarch:amd64
BucketsEqual/same_20_values-12         0.00           0.00        ~     (all equal)
BucketsEqual/same_20_durations-12      0.00           0.00        ~     (all equal)
NameGeneration-12                      0.00           0.00        ~     (all equal)
CounterAllocation-12                   1.00 ± 0%      1.00 ± 0%   ~     (all equal)
SanitizedCounterAllocation-12          4.00 ± 0%      4.00 ± 0%   ~     (all equal)
NameGenerationTagged-12                0.00           0.00        ~     (all equal)
ScopeTaggedCachedSubscopes-12          8.00 ± 0%      8.00 ± 0%   ~     (all equal)
ScopeTaggedNoCachedSubscopes-12        19.0 ± 0%      19.0 ± 0%   ~     (all equal)
NameGenerationNoPrefix-12              0.00           0.00        ~     (all equal)
HistogramAllocation-12                 20.0 ± 0%      20.0 ± 0%   ~     (all equal)
HistogramExisting-12                   0.00           0.00        ~     (all equal)
ScopeReporting/size1-12                0.00           0.00        ~     (all equal)
ScopeReporting/size10-12               0.00           0.00        ~     (all equal)
ScopeReporting/size100-12              0.00           0.00        ~     (all equal)
ScopeReporting/size1000-12             0.00           0.00        ~     (all equal)
ScopeReporting/size10000-12            0.00           0.00        ~     (all equal)
ScopeReporting/size100000-12           0.00           0.00        ~     (all equal)
ScopeReporting/size1000000-12          0.00           0.00        ~     (all equal)
CounterInc-12                          0.00           0.00        ~     (all equal)
ReportCounterNoData-12                 0.00           0.00        ~     (all equal)
ReportCounterWithData-12               0.00           0.00        ~     (all equal)
GaugeSet-12                            0.00           0.00        ~     (all equal)
ReportGaugeNoData-12                   0.00           0.00        ~     (all equal)
ReportGaugeWithData-12                 0.00           0.00        ~     (all equal)
TimerStopwatch-12                      0.00           0.00        ~     (all equal)
TimerReport-12                         0.00           0.00        ~     (all equal)

```
