### PR TITLE
m3/thriftudp: bump SO_RCVBUF on the UDP server socket

### DIFF
--- a/m3/thriftudp/transport_linux.go
+++ b/m3/thriftudp/transport_linux.go
@@ -1,0 +1,26 @@
+package thriftudp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+const _rcvbufMaxProcPath = "/proc/sys/net/core/rmem_max"
+
+func init() {
+	sysconfRcvbufMax = sysconfRcvbufMaxFromProc
+}
+
+func sysconfRcvbufMaxFromProc() (int, error) {
+	buf, err := ioutil.ReadFile(_rcvbufMaxProcPath)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(buf)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %v", _rcvbufMaxProcPath, err)
+	}
+	return int(n), nil
+}


### PR DESCRIPTION
Metric submissions that microburst may momentarily overflow the in-kernel receive buffer.
Reduce data loss risk by expanding the receive buffer to the maximum allowed size.

Ref M3-1034