### PR TITLE
Bump default M3 packet size

### DIFF
--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -61,7 +61,7 @@ const (
 	// DefaultMaxQueueSize is the default M3 reporter queue size.
 	DefaultMaxQueueSize = 4096
 	// DefaultMaxPacketSize is the default M3 reporter max packet size.
-	DefaultMaxPacketSize = int32(1440)
+	DefaultMaxPacketSize = int32(32768)
 	// DefaultHistogramBucketIDName is the default histogram bucket ID tag name
 	DefaultHistogramBucketIDName = "bucketid"
 	// DefaultHistogramBucketName is the default histogram bucket name tag name


### PR DESCRIPTION
I don't know why packets were bounded to MTU before, but let's make the default sane and not tank performance for non-trivial metric counts, even if the users are not using a wrapper on top of Tally that does the right thing configuration-wise.