### PR TITLE
Update Prometheus client

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bfadfc85c3b6bf803090b34bbbcc4b9e16165226e8b4c194658b8ba105c3438b
-updated: 2021-02-11T15:18:03.188401-05:00
+hash: 23f5ede86d6a4b9970e0d5ae025de37ab77246e36dbe5dbae98be73722e4954e
+updated: 2022-06-02T16:30:47.793742-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -10,36 +10,73 @@ imports:
   subpackages:
   - statsd
 - name: github.com/golang/protobuf
-  version: 6c65a5562fc06764971b7c5d05c76c75e84bdbf7
+  version: ae97035608a719c7a1c1c41bed0ae0744bdb0c6f
   subpackages:
   - proto
+  - ptypes/timestamp
 - name: github.com/m3db/prometheus_client_golang
-  version: 8ae269d24972b8695572fa6b2e3718b5ea82d6b4
+  version: a457ed11e3d6f6b70bf47f9aa8a92e4136c941ff
   subpackages:
   - prometheus
+  - prometheus/internal
+  - prometheus/internal/thirdparty/github.com/cespare/xxhash
   - prometheus/promhttp
 - name: github.com/m3db/prometheus_client_model
-  version: d3fff8420252ef63bffb96f689d1a85096c97321
+  version: 1d700e8aacc1ee332fb23c430617f09f5b4f56eb
   subpackages:
   - go
 - name: github.com/m3db/prometheus_common
-  version: d550673fc477123acb69017380567e8fafc765fc
+  version: bd06b6bd06817a628eae4783b5a7b8f85c6da410
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
-- name: github.com/m3db/prometheus_procfs
-  version: 1878d9fbb537119d24b21ca07effd591627cd160
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/pkg/errors
   version: 614d223910a179a466c1767a985424175c39b465
+- name: github.com/prometheus/procfs
+  version: f436cbb89ece38bf080d446b3ca27053b305eaac
+  subpackages:
+  - internal/fs
+  - internal/util
 - name: github.com/twmb/murmur3
-  version: 610077ff6fd864908e4604f64b6c0fc000aa6232
+  version: ae8d9b870b19ddd1cae2d86cfff5278d931d94b8
 - name: go.uber.org/atomic
-  version: 12f27ba2637fa0e13772a4f05fa46a5d18d53182
+  version: 3504dfaa1fa414923b1c8693f45d2f6931daf229
+- name: google.golang.org/protobuf
+  version: 32051b4f86e54c2142c7c05362c6e96ae3454a1c
+  subpackages:
+  - encoding/prototext
+  - encoding/protowire
+  - internal/descfmt
+  - internal/descopts
+  - internal/detrand
+  - internal/encoding/defval
+  - internal/encoding/messageset
+  - internal/encoding/tag
+  - internal/encoding/text
+  - internal/errors
+  - internal/filedesc
+  - internal/filetype
+  - internal/flags
+  - internal/genid
+  - internal/impl
+  - internal/order
+  - internal/pragma
+  - internal/set
+  - internal/strs
+  - internal/version
+  - proto
+  - reflect/protodesc
+  - reflect/protoreflect
+  - reflect/protoregistry
+  - runtime/protoiface
+  - runtime/protoimpl
+  - types/descriptorpb
+  - types/known/timestamppb
 - name: gopkg.in/validator.v2
   version: 2b28d334fa054977b7c725c7639a1ca4efc18bad
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,21 +5,25 @@ import:
   subpackages:
   - statsd
 - package: github.com/m3db/prometheus_client_golang
-  version: ^0.8.1
+  version: ^1.12.4
   subpackages:
   - prometheus
-- package: github.com/m3db/prometheus_client_model
-  version: ^0.1.0
 - package: github.com/m3db/prometheus_common
-  version: ^0.1.0
-- package: github.com/m3db/prometheus_procfs
-  version: ^0.8.1
+  version: ^0.34.3
+- package: github.com/m3db/prometheus_client_model
+  version: ^0.2.1
+- package: github.com/prometheus/procfs
+  version: ^0.7.3
 - package: go.uber.org/atomic
   version: ^1
 - package: github.com/pkg/errors
   version: ^0.8.1
 - package: github.com/twmb/murmur3
   version: ^1.1.5
+- package: google.golang.org/protobuf
+  version: ^1.27.0
+- package: github.com/golang/protobuf
+  version: ^1.5.2
 testImport:
 - package: github.com/axw/gocov
   version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b

--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -163,8 +163,8 @@ type cachedMetric struct {
 	counter     prom.Counter
 	gauge       prom.Gauge
 	reportTimer func(d time.Duration)
-	histogram   prom.Histogram
-	summary     prom.Summary
+	histogram   prom.Observer
+	summary     prom.Observer
 }
 
 func (m *cachedMetric) ReportCount(value int64) {


### PR DESCRIPTION
Update vendored dependencies to pick up >3 years of changes, as upstream has fixed some issues with metric registration/validation.