### PR TITLE
ValidCharacters.sanitizeFn: Pool buffers

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -58,3 +58,11 @@ func TestSanitizeTestCases(t *testing.T) {
 		require.Equal(t, tc.output, fn(tc.input))
 	}
 }
+
+func BenchmarkSanitizeFn(b *testing.B) {
+	sanitize := newTestSanitizer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sanitize("foo bar")
+	}
+}


### PR DESCRIPTION
`ValidCharacters.sanitizeFn` constructs and throws away a `*bytes.Buffer`
for each sanitize call if any character needed to be sanitized.

The lifetime of this buffer is limited to just the scope of the sanitize
call. This is a very good candidate for pooling.

By pooling these buffers, we're able to bring down cost of sanitization
noticeably:

```
name                          old time/op    new time/op    delta
SanitizeFn-8                    79.0ns ± 0%    56.4ns ± 1%  -28.60%  (p=0.000 n=9+9)
SanitizedCounterAllocation-8     491ns ± 3%     446ns ± 3%   -9.21%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
SanitizeFn-8                     64.0B ± 0%      8.0B ± 0%  -87.50%  (p=0.000 n=10+10)
SanitizedCounterAllocation-8      269B ± 0%      189B ± 2%  -29.72%  (p=0.000 n=7+8)

name                          old allocs/op  new allocs/op  delta
SanitizeFn-8                      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
SanitizedCounterAllocation-8      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```


