### PR TITLE
make: Fix stale targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ _testmain.go
 .DS_Store
 node_modules/
 .idea/
+cover.html

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,68 @@
-export GO15VENDOREXPERIMENT=1
+# "go install"-ed binaries will be placed here during development.
+export GOBIN ?= $(shell pwd)/bin
 
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
-PKGS ?= $(shell glide novendor)
-PKG_FILES ?= *.go example/*.go m3/*.go m3/customtransports m3/thriftudp
+GO_FILES = $(shell find . \
+	   '(' -path '*/.*' -o -path './thirdparty/*' -prune ')' -o \
+	   '(' -type f -a -name '*.go' ')' -print)
+MODULES = . ./tools
+
 LINT_IGNORE = m3/thrift\|thirdparty
-LICENSE_IGNORE = thirdparty
+LICENSE_IGNORE = m3/thrift\|thirdparty
+
+GOLINT = $(GOBIN)/golint
 
 .PHONY: all
 all: lint test
 
-.PHONY: dependencies
-dependencies:
-	@echo "Installing Glide and locked dependencies..."
-	glide --version || go get -u -f github.com/Masterminds/glide
-	glide install
-	@echo "Installing test dependencies..."
-	go install ./vendor/github.com/axw/gocov/gocov
-	go install ./vendor/github.com/mattn/goveralls
-	@echo "Installing golint..."
-	go install ./vendor/github.com/golang/lint/golint
-
 .PHONY: lint
-lint: gomodtidy
-	@rm -rf lint.log
-	@echo "Checking formatting..."
-	@gofmt -d -s $(PKG_FILES) 2>&1 | grep -v '$(LINT_IGNORE)' | tee lint.log
-	@echo "Installing test dependencies for vet..."
-	@go test -i $(PKGS)
+lint: gofmt golint gomodtidy license
+
+.PHONY: golint
+golint: $(GOLINT)
 	@echo "Checking lint..."
-	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | grep -v '$(LINT_IGNORE)' | tee -a lint.log;)
-	@echo "Checking for unresolved FIXMEs..."
-	@git grep -i fixme | grep -v -e vendor -e Makefile | grep -v '$(LINT_IGNORE)' | tee -a lint.log
-	@echo "Checking for license headers..."
-	@./check_license.sh | grep -v '$(LICENSE_IGNORE)' | tee -a lint.log
-	@[ ! -s lint.log ]
+	@$(eval LOG := $(shell mktemp -t golint.XXXXX))
+	@$(GOLINT) ./... | grep -v '$(LINT_IGNORE)' > $(LOG) || true
+	@[ ! -s "$(LOG)" ] || \
+		(echo "golint failed:" | \
+		cat - $(LOG) && false)
+
+$(GOLINT): tools/go.mod
+	cd tools && go install golang.org/x/lint/golint
+
+.PHONY: gofmt
+gofmt:
+	@echo "Checking formatting..."
+	$(eval LOG := $(shell mktemp -t gofmt.XXXXX))
+	@gofmt -e -s -l $(GO_FILES) | grep -v '$(LINT_IGNORE)' > $(LOG) || true
+	@[ ! -s "$(LOG)" ] || \
+		(echo "gofmt failed. Please reformat the following files:" | \
+		cat - $(LOG) && false)
+
 
 .PHONY: gomodtidy
 gomodtidy: go.mod go.sum
-	go mod tidy
+	@echo "Checking go.mod and go.sum..."
+	@$(foreach mod,$(MODULES),\
+		(cd $(mod) && go mod tidy) &&) true
 	@if ! git diff --quiet $^; then \
 		echo "go mod tidy changed files:" && \
 		git status --porcelain $^ && \
 		false; \
 	fi
 
+.PHONY: license
+license: check_license.sh
+	@echo "Checking for license headers..."
+	$(eval LOG := $(shell mktemp -t gofmt.XXXXX))
+	@./check_license.sh | grep -v '$(LICENSE_IGNORE)' > $(LOG) || true
+	@[ ! -s "$(LOG)" ] || \
+		(echo "Missing license headers in some files:" | \
+		cat - $(LOG) && false)
+
 .PHONY: test
 test:
-	go test -race -v $(PKGS)
+	go test -race -v ./...
 
 .PHONY: examples
 examples:
@@ -58,13 +74,11 @@ examples:
 
 .PHONY: cover
 cover:
-	go test -cover -coverprofile cover.out -race -v $(PKGS)
-
-.PHONY: coveralls
-coveralls:
-	goveralls -service=travis-ci || echo "Coveralls failed"
+	go test -cover -coverprofile=cover.out -coverpkg=./... -race -v ./...
+	go tool cover -html=cover.out -o cover.html
 
 .PHONY: bench
 BENCH ?= .
 bench:
-	@$(foreach pkg,$(PKGS),go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) $(pkg);)
+	go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) ./...
+

--- a/check_license.sh
+++ b/check_license.sh
@@ -1,4 +1,16 @@
-#!/bin/bash
+#!/bin/bash -e
 
-./node_modules/.bin/uber-licence --version || npm i uber-licence@latest
-./node_modules/.bin/uber-licence --dry --file "*.go"
+ERROR_COUNT=0
+while read -r file
+do
+	case "$(head -1 "${file}")" in
+		*"Copyright (c) "*" Uber Technologies, Inc.")
+			# everything's cool
+			;;
+		*)
+			echo "$file:missing license header."
+			(( ERROR_COUNT++ ))
+			;;
+	esac
+done < <(git ls-files "*\.go")
+exit "$ERROR_COUNT"

--- a/key_gen.go
+++ b/key_gen.go
@@ -42,6 +42,7 @@ func KeyForPrefixedStringMap(
 ) string {
 	return keyForPrefixedStringMaps(prefix, stringMap)
 }
+
 // keyForPrefixedStringMapsAsKey writes a key using the prefix and the tags in a canonical form to
 // the given input byte slice and returns a reference to the byte slice. Callers of this method can
 // use a stack allocated byte slice to remove heap allocation.

--- a/tools/doc.go
+++ b/tools/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package tools adds dependencies on tools used while developing tally that
+// should not be included in its dependencies.
+package tools

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,7 @@
+module github.com/uber-go/tally/tools
+
+go 1.18
+
+require golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
+
+require golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,14 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "golang.org/x/lint/golint"
+)


### PR DESCRIPTION
Rewrite parts of the Makefile based on Zap's Makefile and from other
more recent Makefiles:

Specifically:

- Use a tools submodule to manage development tools so these are not
  added as dependencies of tally.
- Use GOBIN to install third party tools into a local directory.
- Manage different kinds of lint checks as their own independent
  targets.
- Use a simple license check instead of relying on an unmaintained
  NodeJS tool.
- Generate an HTML coverage report on `make cover`.
- Use `./...` instead of `glide nv` -- this has been supported for a
  very long time.
