### PR TITLE
Terminate timeloop faster for m3

### DIFF
--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -697,7 +697,7 @@ func (r *reporter) timeLoop() {
 		select {
 		case <-time.After(_timeResolution):
 		    break
-		case <-doneCh:
+		case <-donech:
 		    return
 		}
 	}

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -698,7 +698,6 @@ func (r *reporter) timeLoop() {
 		r.now.Store(time.Now().UnixNano())
 		select {
 		case <-t.C:
-			break
 		case <-r.donech:
 			return
 		}

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -696,9 +696,9 @@ func (r *reporter) timeLoop() {
 		r.now.Store(time.Now().UnixNano())
 		select {
 		case <-time.After(_timeResolution):
-		    break
+			break
 		case <-donech:
-		    return
+			return
 		}
 	}
 }

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -692,10 +692,12 @@ func (r *reporter) reportInternalMetrics() {
 }
 
 func (r *reporter) timeLoop() {
+	t := time.NewTicker(_timeResolution)
+	defer t.Stop()
 	for !r.done.Load() {
 		r.now.Store(time.Now().UnixNano())
 		select {
-		case <-time.After(_timeResolution):
+		case <-t.C:
 			break
 		case <-r.donech:
 			return

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -697,7 +697,7 @@ func (r *reporter) timeLoop() {
 		select {
 		case <-time.After(_timeResolution):
 			break
-		case <-donech:
+		case <-r.donech:
 			return
 		}
 	}


### PR DESCRIPTION
We quickly start and stop process (it is wrapper for another command) and timeloop potentially can delay process shutdown by up-to 100ms (_timeResolution). Instead of just sleeping we as well wait for signal that shutdown is in progress and quickly terminate loop.