### PR TITLE
Fix for bad prometheus metrics name

### DIFF
--- a/m3/reporter_integration_test.go
+++ b/m3/reporter_integration_test.go
@@ -110,7 +110,7 @@ func testProcessFlushOnExit(t *testing.T, i int) {
 	require.Equal(t, 1, len(server.Service.getBatches()))
 	require.NotNil(t, server.Service.getBatches()[0])
 	// 3 metrics are emitted by mainFileFmt plus various other internal metrics.
-	require.Equal(t, internalMetrics+cardinalityMetrics+3, len(server.Service.getBatches()[0].GetMetrics()))
+	require.Equal(t, internalMetrics+3, len(server.Service.getBatches()[0].GetMetrics()))
 	metrics := server.Service.getBatches()[0].GetMetrics()
 	fmt.Printf("Test %d emitted:\n%v\n", i, metrics)
 }

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,7 @@ func newTestReporterScope(
 		Prefix:         scopePrefix,
 		Tags:           scopeTags,
 		CachedReporter: r,
+		MetricsOption:  tally.SendInternalMetrics,
 	}, shortInterval)
 
 	return r, scope, func() {

--- a/scope.go
+++ b/scope.go
@@ -105,15 +105,15 @@ type scope struct {
 
 // ScopeOptions is a set of options to construct a scope.
 type ScopeOptions struct {
-	Tags                  map[string]string
-	Prefix                string
-	Reporter              StatsReporter
-	CachedReporter        CachedStatsReporter
-	Separator             string
-	DefaultBuckets        Buckets
-	SanitizeOptions       *SanitizeOptions
-	registryShardCount    uint
-	internalMetricsOption InternalMetricOption
+	Tags               map[string]string
+	Prefix             string
+	Reporter           StatsReporter
+	CachedReporter     CachedStatsReporter
+	Separator          string
+	DefaultBuckets     Buckets
+	SanitizeOptions    *SanitizeOptions
+	registryShardCount uint
+	MetricsOption      InternalMetricOption
 }
 
 // NewRootScope creates a new root Scope with a set of options and
@@ -183,7 +183,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 	s.tags = s.copyAndSanitizeMap(opts.Tags)
 
 	// Register the root scope
-	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.internalMetricsOption)
+	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.MetricsOption)
 
 	if interval > 0 {
 		s.wg.Add(1)

--- a/scope.go
+++ b/scope.go
@@ -28,11 +28,15 @@ import (
 	"go.uber.org/atomic"
 )
 
+// InternalMetricOption is used to configure internal metrics.
 type InternalMetricOption int
 
 const (
+	// Unset is the "no-op" config, which turns off internal metrics.
 	Unset InternalMetricOption = iota
+	// SendInternalMetrics turns on internal metrics submission.
 	SendInternalMetrics
+	// OmitInternalMetrics turns off internal metrics submission.
 	OmitInternalMetrics
 
 	_defaultInitialSliceSize = 16

--- a/scope.go
+++ b/scope.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,13 @@ import (
 	"go.uber.org/atomic"
 )
 
+type InternalMetricOption int
+
 const (
+	Unset InternalMetricOption = iota
+	SendInternalMetrics
+	OmitInternalMetrics
+
 	_defaultInitialSliceSize = 16
 )
 
@@ -95,15 +101,15 @@ type scope struct {
 
 // ScopeOptions is a set of options to construct a scope.
 type ScopeOptions struct {
-	Tags                map[string]string
-	Prefix              string
-	Reporter            StatsReporter
-	CachedReporter      CachedStatsReporter
-	Separator           string
-	DefaultBuckets      Buckets
-	SanitizeOptions     *SanitizeOptions
-	registryShardCount  uint
-	skipInternalMetrics bool
+	Tags                  map[string]string
+	Prefix                string
+	Reporter              StatsReporter
+	CachedReporter        CachedStatsReporter
+	Separator             string
+	DefaultBuckets        Buckets
+	SanitizeOptions       *SanitizeOptions
+	registryShardCount    uint
+	internalMetricsOption InternalMetricOption
 }
 
 // NewRootScope creates a new root Scope with a set of options and
@@ -173,7 +179,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 	s.tags = s.copyAndSanitizeMap(opts.Tags)
 
 	// Register the root scope
-	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.skipInternalMetrics)
+	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.internalMetricsOption)
 
 	if interval > 0 {
 		s.wg.Add(1)

--- a/scope_registry_test.go
+++ b/scope_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ func TestVerifyCachedTaggedScopesAlloc(t *testing.T) {
 
 func TestNewTestStatsReporterOneScope(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: false}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: SendInternalMetrics}, 0)
 	s := root.(*scope)
 
 	numFakeCounters := 3
@@ -101,7 +101,7 @@ func TestNewTestStatsReporterOneScope(t *testing.T) {
 
 func TestNewTestStatsReporterManyScopes(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: false}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: SendInternalMetrics}, 0)
 	wantCounters, wantGauges, wantHistograms := int64(3), int64(2), int64(1)
 
 	s := root.(*scope)

--- a/scope_registry_test.go
+++ b/scope_registry_test.go
@@ -55,7 +55,7 @@ func TestVerifyCachedTaggedScopesAlloc(t *testing.T) {
 
 func TestNewTestStatsReporterOneScope(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: SendInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: SendInternalMetrics}, 0)
 	s := root.(*scope)
 
 	numFakeCounters := 3
@@ -101,7 +101,7 @@ func TestNewTestStatsReporterOneScope(t *testing.T) {
 
 func TestNewTestStatsReporterManyScopes(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: SendInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: SendInternalMetrics}, 0)
 	wantCounters, wantGauges, wantHistograms := int64(3), int64(2), int64(1)
 
 	s := root.(*scope)

--- a/scope_test.go
+++ b/scope_test.go
@@ -355,7 +355,7 @@ func (r *testStatsReporter) Flush() {
 
 func TestWriteTimerImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	s.Timer("ticky").Record(time.Millisecond * 175)
@@ -364,7 +364,7 @@ func TestWriteTimerImmediately(t *testing.T) {
 
 func TestWriteTimerClosureImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	tm := s.Timer("ticky")
@@ -374,7 +374,7 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 
 func TestWriteReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 10)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -392,7 +392,7 @@ func TestWriteReportLoop(t *testing.T) {
 
 func TestCachedReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}, 10)
+	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -410,9 +410,9 @@ func TestCachedReportLoop(t *testing.T) {
 func testReportLoopFlushOnce(t *testing.T, cached bool) {
 	r := newTestStatsReporter()
 
-	scopeOpts := ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}
+	scopeOpts := ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}
 	if !cached {
-		scopeOpts = ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}
+		scopeOpts = ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}
 	}
 
 	s, closer := NewRootScope(scopeOpts, 10*time.Minute)
@@ -450,7 +450,7 @@ func TestReporterFlushOnce(t *testing.T) {
 func TestWriteOnce(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -521,10 +521,10 @@ func TestHistogramSharedBucketMetrics(t *testing.T) {
 	var (
 		r     = newTestStatsReporter()
 		scope = newRootScope(ScopeOptions{
-			Prefix:                "",
-			Tags:                  nil,
-			CachedReporter:        r,
-			internalMetricsOption: OmitInternalMetrics,
+			Prefix:         "",
+			Tags:           nil,
+			CachedReporter: r,
+			MetricsOption:  OmitInternalMetrics,
 		}, 0)
 		builder = func(s Scope) func(map[string]string) {
 			buckets := MustMakeLinearValueBuckets(10, 10, 3)
@@ -595,10 +595,10 @@ func TestConcurrentUpdates(t *testing.T) {
 		counterIncrs     = 5000
 		rs               = newRootScope(
 			ScopeOptions{
-				Prefix:                "",
-				Tags:                  nil,
-				CachedReporter:        r,
-				internalMetricsOption: OmitInternalMetrics,
+				Prefix:         "",
+				Tags:           nil,
+				CachedReporter: r,
+				MetricsOption:  OmitInternalMetrics,
 			}, 0,
 		)
 		scopes   = []Scope{rs}
@@ -644,9 +644,9 @@ func TestCounterSanitized(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(ScopeOptions{
-		Reporter:              r,
-		SanitizeOptions:       &alphanumericSanitizerOpts,
-		internalMetricsOption: OmitInternalMetrics,
+		Reporter:        r,
+		SanitizeOptions: &alphanumericSanitizerOpts,
+		MetricsOption:   OmitInternalMetrics,
 	}, 0)
 	defer closer.Close()
 
@@ -702,7 +702,7 @@ func TestCounterSanitized(t *testing.T) {
 func TestCachedReporter(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -739,7 +739,7 @@ func TestCachedReporter(t *testing.T) {
 func TestRootScopeWithoutPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -774,7 +774,7 @@ func TestRootScopeWithPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(
-		ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0,
+		ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0,
 	)
 	defer closer.Close()
 
@@ -811,7 +811,7 @@ func TestRootScopeWithDifferentSeparator(t *testing.T) {
 
 	root, closer := NewRootScope(
 		ScopeOptions{
-			Prefix: "foo", Separator: "_", Reporter: r, internalMetricsOption: OmitInternalMetrics,
+			Prefix: "foo", Separator: "_", Reporter: r, MetricsOption: OmitInternalMetrics,
 		}, 0,
 	)
 	defer closer.Close()
@@ -848,7 +848,7 @@ func TestSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(
-		ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0,
+		ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0,
 	)
 	defer closer.Close()
 
@@ -891,7 +891,7 @@ func TestSubScope(t *testing.T) {
 func TestSubScopeClose(t *testing.T) {
 	r := newTestStatsReporter()
 
-	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	// defer closer.Close()
 	_ = closer
 
@@ -984,7 +984,7 @@ func TestTaggedSubScope(t *testing.T) {
 	ts := map[string]string{"env": "test"}
 	root, closer := NewRootScope(
 		ScopeOptions{
-			Prefix: "foo", Tags: ts, Reporter: r, internalMetricsOption: OmitInternalMetrics,
+			Prefix: "foo", Tags: ts, Reporter: r, MetricsOption: OmitInternalMetrics,
 		}, 0,
 	)
 	defer closer.Close()
@@ -1042,11 +1042,11 @@ func TestTaggedSanitizedSubScope(t *testing.T) {
 
 	ts := map[string]string{"env": "test:env"}
 	root, closer := NewRootScope(ScopeOptions{
-		Prefix:                "foo",
-		Tags:                  ts,
-		Reporter:              r,
-		SanitizeOptions:       &alphanumericSanitizerOpts,
-		internalMetricsOption: OmitInternalMetrics,
+		Prefix:          "foo",
+		Tags:            ts,
+		Reporter:        r,
+		SanitizeOptions: &alphanumericSanitizerOpts,
+		MetricsOption:   OmitInternalMetrics,
 	}, 0)
 	defer closer.Close()
 	s := root.(*scope)
@@ -1079,7 +1079,7 @@ func TestTaggedExistingReturnsSameScope(t *testing.T) {
 	} {
 		root, closer := NewRootScope(
 			ScopeOptions{
-				Prefix: "foo", Tags: initialTags, Reporter: r, internalMetricsOption: OmitInternalMetrics,
+				Prefix: "foo", Tags: initialTags, Reporter: r, MetricsOption: OmitInternalMetrics,
 			}, 0,
 		)
 		defer closer.Close()
@@ -1168,7 +1168,7 @@ func TestSnapshot(t *testing.T) {
 
 func TestCapabilities(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	assert.True(t, s.Capabilities().Reporting())
 	assert.False(t, s.Capabilities().Tagging())
@@ -1196,8 +1196,8 @@ func TestScopeDefaultBuckets(t *testing.T) {
 			90 * time.Millisecond,
 			120 * time.Millisecond,
 		},
-		Reporter:              r,
-		internalMetricsOption: OmitInternalMetrics,
+		Reporter:      r,
+		MetricsOption: OmitInternalMetrics,
 	}, 0)
 	defer closer.Close()
 
@@ -1228,7 +1228,7 @@ func newTestMets(scope Scope) testMets {
 func TestReturnByValue(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1245,7 +1245,7 @@ func TestReturnByValue(t *testing.T) {
 
 func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
 
 	s := root.(*scope)
 	s.reportLoopRun()
@@ -1260,7 +1260,7 @@ func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 
 func TestScopeFlushOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, time.Hour)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, time.Hour)
 
 	r.cg.Add(1)
 	root.Counter("foo").Inc(1)

--- a/scope_test.go
+++ b/scope_test.go
@@ -520,14 +520,12 @@ func TestWriteOnce(t *testing.T) {
 func TestHistogramSharedBucketMetrics(t *testing.T) {
 	var (
 		r     = newTestStatsReporter()
-		scope = newRootScope(
-			ScopeOptions{
-				Prefix:                "",
-				Tags:                  nil,
-				CachedReporter:        r,
-				internalMetricsOption: OmitInternalMetrics,
-			}, 0,
-		)
+		scope = newRootScope(ScopeOptions{
+			Prefix:                "",
+			Tags:                  nil,
+			CachedReporter:        r,
+			internalMetricsOption: OmitInternalMetrics,
+		}, 0)
 		builder = func(s Scope) func(map[string]string) {
 			buckets := MustMakeLinearValueBuckets(10, 10, 3)
 			return func(tags map[string]string) {
@@ -645,13 +643,11 @@ func TestConcurrentUpdates(t *testing.T) {
 func TestCounterSanitized(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(
-		ScopeOptions{
-			Reporter:              r,
-			SanitizeOptions:       &alphanumericSanitizerOpts,
-			internalMetricsOption: OmitInternalMetrics,
-		}, 0,
-	)
+	root, closer := NewRootScope(ScopeOptions{
+		Reporter:              r,
+		SanitizeOptions:       &alphanumericSanitizerOpts,
+		internalMetricsOption: OmitInternalMetrics,
+	}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1045,15 +1041,13 @@ func TestTaggedSanitizedSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
 	ts := map[string]string{"env": "test:env"}
-	root, closer := NewRootScope(
-		ScopeOptions{
-			Prefix:                "foo",
-			Tags:                  ts,
-			Reporter:              r,
-			SanitizeOptions:       &alphanumericSanitizerOpts,
-			internalMetricsOption: OmitInternalMetrics,
-		}, 0,
-	)
+	root, closer := NewRootScope(ScopeOptions{
+		Prefix:                "foo",
+		Tags:                  ts,
+		Reporter:              r,
+		SanitizeOptions:       &alphanumericSanitizerOpts,
+		internalMetricsOption: OmitInternalMetrics,
+	}, 0)
 	defer closer.Close()
 	s := root.(*scope)
 
@@ -1194,19 +1188,17 @@ func TestNilTagMerge(t *testing.T) {
 func TestScopeDefaultBuckets(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(
-		ScopeOptions{
-			DefaultBuckets: DurationBuckets{
-				0 * time.Millisecond,
-				30 * time.Millisecond,
-				60 * time.Millisecond,
-				90 * time.Millisecond,
-				120 * time.Millisecond,
-			},
-			Reporter:              r,
-			internalMetricsOption: OmitInternalMetrics,
-		}, 0,
-	)
+	root, closer := NewRootScope(ScopeOptions{
+		DefaultBuckets: DurationBuckets{
+			0 * time.Millisecond,
+			30 * time.Millisecond,
+			60 * time.Millisecond,
+			90 * time.Millisecond,
+			120 * time.Millisecond,
+		},
+		Reporter:              r,
+		internalMetricsOption: OmitInternalMetrics,
+	}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)

--- a/scope_test.go
+++ b/scope_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -288,8 +288,10 @@ type testStatsReporterCachedHistogramValueBucket struct {
 }
 
 func (b testStatsReporterCachedHistogramValueBucket) ReportSamples(v int64) {
-	b.histogram.r.ReportHistogramValueSamples(b.histogram.name, b.histogram.tags,
-		b.histogram.buckets, b.bucketLowerBound, b.bucketUpperBound, v)
+	b.histogram.r.ReportHistogramValueSamples(
+		b.histogram.name, b.histogram.tags,
+		b.histogram.buckets, b.bucketLowerBound, b.bucketUpperBound, v,
+	)
 }
 
 type testStatsReporterCachedHistogramDurationBucket struct {
@@ -299,8 +301,10 @@ type testStatsReporterCachedHistogramDurationBucket struct {
 }
 
 func (b testStatsReporterCachedHistogramDurationBucket) ReportSamples(v int64) {
-	b.histogram.r.ReportHistogramDurationSamples(b.histogram.name, b.histogram.tags,
-		b.histogram.buckets, b.bucketLowerBound, b.bucketUpperBound, v)
+	b.histogram.r.ReportHistogramDurationSamples(
+		b.histogram.name, b.histogram.tags,
+		b.histogram.buckets, b.bucketLowerBound, b.bucketUpperBound, v,
+	)
 }
 
 func (r *testStatsReporter) ReportHistogramValueSamples(
@@ -351,7 +355,7 @@ func (r *testStatsReporter) Flush() {
 
 func TestWriteTimerImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	s.Timer("ticky").Record(time.Millisecond * 175)
@@ -360,7 +364,7 @@ func TestWriteTimerImmediately(t *testing.T) {
 
 func TestWriteTimerClosureImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	tm := s.Timer("ticky")
@@ -370,7 +374,7 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 
 func TestWriteReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 10)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -388,7 +392,7 @@ func TestWriteReportLoop(t *testing.T) {
 
 func TestCachedReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, skipInternalMetrics: true}, 10)
+	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -406,9 +410,9 @@ func TestCachedReportLoop(t *testing.T) {
 func testReportLoopFlushOnce(t *testing.T, cached bool) {
 	r := newTestStatsReporter()
 
-	scopeOpts := ScopeOptions{CachedReporter: r, skipInternalMetrics: true}
+	scopeOpts := ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}
 	if !cached {
-		scopeOpts = ScopeOptions{Reporter: r, skipInternalMetrics: true}
+		scopeOpts = ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}
 	}
 
 	s, closer := NewRootScope(scopeOpts, 10*time.Minute)
@@ -446,7 +450,7 @@ func TestReporterFlushOnce(t *testing.T) {
 func TestWriteOnce(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -516,12 +520,14 @@ func TestWriteOnce(t *testing.T) {
 func TestHistogramSharedBucketMetrics(t *testing.T) {
 	var (
 		r     = newTestStatsReporter()
-		scope = newRootScope(ScopeOptions{
-			Prefix:              "",
-			Tags:                nil,
-			CachedReporter:      r,
-			skipInternalMetrics: true,
-		}, 0)
+		scope = newRootScope(
+			ScopeOptions{
+				Prefix:                "",
+				Tags:                  nil,
+				CachedReporter:        r,
+				internalMetricsOption: OmitInternalMetrics,
+			}, 0,
+		)
 		builder = func(s Scope) func(map[string]string) {
 			buckets := MustMakeLinearValueBuckets(10, 10, 3)
 			return func(tags map[string]string) {
@@ -543,9 +549,11 @@ func TestHistogramSharedBucketMetrics(t *testing.T) {
 			defer wg.Done()
 
 			val := strconv.Itoa(i % 4)
-			record(map[string]string{
-				"key": val,
-			})
+			record(
+				map[string]string{
+					"key": val,
+				},
+			)
 
 			time.Sleep(time.Duration(rand.Float64() * float64(time.Second)))
 		}()
@@ -589,10 +597,10 @@ func TestConcurrentUpdates(t *testing.T) {
 		counterIncrs     = 5000
 		rs               = newRootScope(
 			ScopeOptions{
-				Prefix:              "",
-				Tags:                nil,
-				CachedReporter:      r,
-				skipInternalMetrics: true,
+				Prefix:                "",
+				Tags:                  nil,
+				CachedReporter:        r,
+				internalMetricsOption: OmitInternalMetrics,
 			}, 0,
 		)
 		scopes   = []Scope{rs}
@@ -637,11 +645,13 @@ func TestConcurrentUpdates(t *testing.T) {
 func TestCounterSanitized(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{
-		Reporter:            r,
-		SanitizeOptions:     &alphanumericSanitizerOpts,
-		skipInternalMetrics: true,
-	}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{
+			Reporter:              r,
+			SanitizeOptions:       &alphanumericSanitizerOpts,
+			internalMetricsOption: OmitInternalMetrics,
+		}, 0,
+	)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -696,7 +706,7 @@ func TestCounterSanitized(t *testing.T) {
 func TestCachedReporter(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -733,7 +743,7 @@ func TestCachedReporter(t *testing.T) {
 func TestRootScopeWithoutPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -767,7 +777,9 @@ func TestRootScopeWithoutPrefix(t *testing.T) {
 func TestRootScopeWithPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0,
+	)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -801,7 +813,11 @@ func TestRootScopeWithPrefix(t *testing.T) {
 func TestRootScopeWithDifferentSeparator(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Prefix: "foo", Separator: "_", Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{
+			Prefix: "foo", Separator: "_", Reporter: r, internalMetricsOption: OmitInternalMetrics,
+		}, 0,
+	)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -835,7 +851,9 @@ func TestRootScopeWithDifferentSeparator(t *testing.T) {
 func TestSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0,
+	)
 	defer closer.Close()
 
 	tags := map[string]string{"foo": "bar"}
@@ -877,7 +895,7 @@ func TestSubScope(t *testing.T) {
 func TestSubScopeClose(t *testing.T) {
 	r := newTestStatsReporter()
 
-	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, skipInternalMetrics: true}, 0)
+	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	// defer closer.Close()
 	_ = closer
 
@@ -968,7 +986,11 @@ func TestTaggedSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
 	ts := map[string]string{"env": "test"}
-	root, closer := NewRootScope(ScopeOptions{Prefix: "foo", Tags: ts, Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{
+			Prefix: "foo", Tags: ts, Reporter: r, internalMetricsOption: OmitInternalMetrics,
+		}, 0,
+	)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1000,32 +1022,38 @@ func TestTaggedSubScope(t *testing.T) {
 	assert.EqualValues(t, ts, counters["foo.beep"].tags)
 
 	assert.EqualValues(t, 1, counters["foo.boop"].val)
-	assert.EqualValues(t, map[string]string{
-		"env":     "test",
-		"service": "test",
-	}, counters["foo.boop"].tags)
+	assert.EqualValues(
+		t, map[string]string{
+			"env":     "test",
+			"service": "test",
+		}, counters["foo.boop"].tags,
+	)
 
 	assert.EqualValues(t, 1, histograms["foo.baz"].valueSamples[50.0])
 	assert.EqualValues(t, ts, histograms["foo.baz"].tags)
 
 	assert.EqualValues(t, 1, histograms["foo.bar"].valueSamples[50.0])
-	assert.EqualValues(t, map[string]string{
-		"env":     "test",
-		"service": "test",
-	}, histograms["foo.bar"].tags)
+	assert.EqualValues(
+		t, map[string]string{
+			"env":     "test",
+			"service": "test",
+		}, histograms["foo.bar"].tags,
+	)
 }
 
 func TestTaggedSanitizedSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
 	ts := map[string]string{"env": "test:env"}
-	root, closer := NewRootScope(ScopeOptions{
-		Prefix:              "foo",
-		Tags:                ts,
-		Reporter:            r,
-		SanitizeOptions:     &alphanumericSanitizerOpts,
-		skipInternalMetrics: true,
-	}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{
+			Prefix:                "foo",
+			Tags:                  ts,
+			Reporter:              r,
+			SanitizeOptions:       &alphanumericSanitizerOpts,
+			internalMetricsOption: OmitInternalMetrics,
+		}, 0,
+	)
 	defer closer.Close()
 	s := root.(*scope)
 
@@ -1040,10 +1068,12 @@ func TestTaggedSanitizedSubScope(t *testing.T) {
 
 	counters := r.getCounters()
 	assert.EqualValues(t, 1, counters["foo_beep"].val)
-	assert.EqualValues(t, map[string]string{
-		"env":     "test_env",
-		"service": "test_service",
-	}, counters["foo_beep"].tags)
+	assert.EqualValues(
+		t, map[string]string{
+			"env":     "test_env",
+			"service": "test_service",
+		}, counters["foo_beep"].tags,
+	)
 }
 
 func TestTaggedExistingReturnsSameScope(t *testing.T) {
@@ -1053,7 +1083,11 @@ func TestTaggedExistingReturnsSameScope(t *testing.T) {
 		nil,
 		{"env": "test"},
 	} {
-		root, closer := NewRootScope(ScopeOptions{Prefix: "foo", Tags: initialTags, Reporter: r, skipInternalMetrics: true}, 0)
+		root, closer := NewRootScope(
+			ScopeOptions{
+				Prefix: "foo", Tags: initialTags, Reporter: r, internalMetricsOption: OmitInternalMetrics,
+			}, 0,
+		)
 		defer closer.Close()
 
 		rootScope := root.(*scope)
@@ -1085,52 +1119,62 @@ func TestSnapshot(t *testing.T) {
 
 	// Should be able to call Snapshot any number of times and get same result.
 	for i := 0; i < 3; i++ {
-		t.Run(fmt.Sprintf("attempt %d", i), func(t *testing.T) {
-			snap := s.Snapshot()
-			counters, gauges, timers, histograms :=
-				snap.Counters(), snap.Gauges(), snap.Timers(), snap.Histograms()
+		t.Run(
+			fmt.Sprintf("attempt %d", i), func(t *testing.T) {
+				snap := s.Snapshot()
+				counters, gauges, timers, histograms :=
+					snap.Counters(), snap.Gauges(), snap.Timers(), snap.Histograms()
 
-			assert.EqualValues(t, 1, counters["foo.beep+env=test"].Value())
-			assert.EqualValues(t, commonTags, counters["foo.beep+env=test"].Tags())
+				assert.EqualValues(t, 1, counters["foo.beep+env=test"].Value())
+				assert.EqualValues(t, commonTags, counters["foo.beep+env=test"].Tags())
 
-			assert.EqualValues(t, 2, gauges["foo.bzzt+env=test"].Value())
-			assert.EqualValues(t, commonTags, gauges["foo.bzzt+env=test"].Tags())
+				assert.EqualValues(t, 2, gauges["foo.bzzt+env=test"].Value())
+				assert.EqualValues(t, commonTags, gauges["foo.bzzt+env=test"].Tags())
 
-			assert.EqualValues(t, []time.Duration{
-				1 * time.Second,
-				2 * time.Second,
-			}, timers["foo.brrr+env=test"].Values())
-			assert.EqualValues(t, commonTags, timers["foo.brrr+env=test"].Tags())
+				assert.EqualValues(
+					t, []time.Duration{
+						1 * time.Second,
+						2 * time.Second,
+					}, timers["foo.brrr+env=test"].Values(),
+				)
+				assert.EqualValues(t, commonTags, timers["foo.brrr+env=test"].Tags())
 
-			assert.EqualValues(t, map[float64]int64{
-				0:               0,
-				2:               1,
-				4:               0,
-				math.MaxFloat64: 1,
-			}, histograms["foo.fizz+env=test"].Values())
-			assert.EqualValues(t, map[time.Duration]int64(nil), histograms["foo.fizz+env=test"].Durations())
-			assert.EqualValues(t, commonTags, histograms["foo.fizz+env=test"].Tags())
+				assert.EqualValues(
+					t, map[float64]int64{
+						0:               0,
+						2:               1,
+						4:               0,
+						math.MaxFloat64: 1,
+					}, histograms["foo.fizz+env=test"].Values(),
+				)
+				assert.EqualValues(t, map[time.Duration]int64(nil), histograms["foo.fizz+env=test"].Durations())
+				assert.EqualValues(t, commonTags, histograms["foo.fizz+env=test"].Tags())
 
-			assert.EqualValues(t, map[float64]int64(nil), histograms["foo.buzz+env=test"].Values())
-			assert.EqualValues(t, map[time.Duration]int64{
-				time.Second * 2: 1,
-				time.Second * 4: 0,
-				math.MaxInt64:   0,
-			}, histograms["foo.buzz+env=test"].Durations())
-			assert.EqualValues(t, commonTags, histograms["foo.buzz+env=test"].Tags())
+				assert.EqualValues(t, map[float64]int64(nil), histograms["foo.buzz+env=test"].Values())
+				assert.EqualValues(
+					t, map[time.Duration]int64{
+						time.Second * 2: 1,
+						time.Second * 4: 0,
+						math.MaxInt64:   0,
+					}, histograms["foo.buzz+env=test"].Durations(),
+				)
+				assert.EqualValues(t, commonTags, histograms["foo.buzz+env=test"].Tags())
 
-			assert.EqualValues(t, 1, counters["foo.boop+env=test,service=test"].Value())
-			assert.EqualValues(t, map[string]string{
-				"env":     "test",
-				"service": "test",
-			}, counters["foo.boop+env=test,service=test"].Tags())
-		})
+				assert.EqualValues(t, 1, counters["foo.boop+env=test,service=test"].Value())
+				assert.EqualValues(
+					t, map[string]string{
+						"env":     "test",
+						"service": "test",
+					}, counters["foo.boop+env=test,service=test"].Tags(),
+				)
+			},
+		)
 	}
 }
 
 func TestCapabilities(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 	assert.True(t, s.Capabilities().Reporting())
 	assert.False(t, s.Capabilities().Tagging())
@@ -1150,17 +1194,19 @@ func TestNilTagMerge(t *testing.T) {
 func TestScopeDefaultBuckets(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{
-		DefaultBuckets: DurationBuckets{
-			0 * time.Millisecond,
-			30 * time.Millisecond,
-			60 * time.Millisecond,
-			90 * time.Millisecond,
-			120 * time.Millisecond,
-		},
-		Reporter:            r,
-		skipInternalMetrics: true,
-	}, 0)
+	root, closer := NewRootScope(
+		ScopeOptions{
+			DefaultBuckets: DurationBuckets{
+				0 * time.Millisecond,
+				30 * time.Millisecond,
+				60 * time.Millisecond,
+				90 * time.Millisecond,
+				120 * time.Millisecond,
+			},
+			Reporter:              r,
+			internalMetricsOption: OmitInternalMetrics,
+		}, 0,
+	)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1190,7 +1236,7 @@ func newTestMets(scope Scope) testMets {
 func TestReturnByValue(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1207,7 +1253,7 @@ func TestReturnByValue(t *testing.T) {
 
 func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, 0)
 
 	s := root.(*scope)
 	s.reportLoopRun()
@@ -1222,7 +1268,7 @@ func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 
 func TestScopeFlushOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, skipInternalMetrics: true}, time.Hour)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, internalMetricsOption: OmitInternalMetrics}, time.Hour)
 
 	r.cg.Add(1)
 	root.Counter("foo").Inc(1)


### PR DESCRIPTION
This resolves https://github.com/uber-go/tally/issues/198 and improves usability of the internal metrics toggle and mirrors the change in the v3 branch.