### PR TITLE
fixing race condition in ForEachScope

### DIFF
--- a/scope_registry.go
+++ b/scope_registry.go
@@ -125,11 +125,11 @@ func (r *scopeRegistry) CachedReport() {
 
 func (r *scopeRegistry) ForEachScope(f func(*scope)) {
 	for _, subscopeBucket := range r.subscopes {
+		subscopeBucket.mu.RLock()
 		for _, s := range subscopeBucket.s {
-			subscopeBucket.mu.RLock()
 			f(s)
-			subscopeBucket.mu.RUnlock()
 		}
+		subscopeBucket.mu.RUnlock()
 	}
 }
 

--- a/scope_registry_test.go
+++ b/scope_registry_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -139,4 +140,22 @@ func TestNewTestStatsReporterManyScopes(t *testing.T) {
 		t, wantHistograms, r.counters[histogramCardinalityName].val, "expected %d counters, got %d histograms",
 		wantHistograms, r.counters[histogramCardinalityName].val,
 	)
+}
+
+func TestForEachScope(t *testing.T) {
+	scope := NewTestScope("", nil)
+	go func() {
+		for {
+			hello := scope.Tagged(map[string]string{"a": "b"}).Counter("hello")
+			hello.Inc(1)
+		}
+	}()
+	var val CounterSnapshot
+	for {
+		val = scope.Snapshot().Counters()["hello+a=b"]
+		if val != nil {
+			break
+		}
+	}
+	require.NotNil(t, val)
 }


### PR DESCRIPTION
This fixes an issue in ForEachScope() where a subscopeBucket could be updated during snapshot.