### PR TITLE
Test with go >= 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: go
 sudo: false
 go:
-  - 1.14.x
-  - 1.15.x
-  - 1.16.x
-env:
-  global:
-    - GO15VENDOREXPERIMENT=1
+  - 1.18.x
+  - 1.19.x
+  - 1.20.x
+  - 1.21.x
 cache:
   directories:
     - vendor


### PR DESCRIPTION
Doesn't make sense to test with ancient Go runtimes - generics are too sweet,
and `m3db/m3` is on 1.18.