### PR TITLE
Use stanard library errors instead of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/cactus/go-statsd-client/v5 v5.0.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -66,7 +66,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -21,6 +21,7 @@
 package m3
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -31,14 +32,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-	tally "github.com/uber-go/tally/v4"
+	"go.uber.org/atomic"
+
+	"github.com/uber-go/tally/v4"
 	"github.com/uber-go/tally/v4/internal/cache"
 	customtransport "github.com/uber-go/tally/v4/m3/customtransports"
 	m3thrift "github.com/uber-go/tally/v4/m3/thrift/v2"
 	"github.com/uber-go/tally/v4/m3/thriftudp"
 	"github.com/uber-go/tally/v4/thirdparty/github.com/apache/thrift/lib/go/thrift"
-	"go.uber.org/atomic"
 )
 
 // Protocol describes a M3 thrift transport protocol.
@@ -220,7 +221,7 @@ func NewReporter(opts Options) (Reporter, error) {
 		if opts.CommonTags[HostTag] == "" {
 			hostname, err := os.Hostname()
 			if err != nil {
-				return nil, errors.WithMessage(err, "error resolving host tag")
+				return nil, fmt.Errorf("error resolving host tag: %w", err)
 			}
 			tagm[HostTag] = hostname
 		}
@@ -243,10 +244,7 @@ func NewReporter(opts Options) (Reporter, error) {
 	)
 
 	if err := batch.Write(proto); err != nil {
-		return nil, errors.WithMessage(
-			err,
-			"failed to write to proto for size calculation",
-		)
+		return nil, fmt.Errorf("failed to write to proto for size calculation: %w", err)
 	}
 
 	resourcePool.releaseMetricSlice(batch.Metrics)

--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -21,15 +21,17 @@
 package prometheus
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	tally "github.com/uber-go/tally/v4"
+
+	"github.com/uber-go/tally/v4"
 )
 
 const (
@@ -295,11 +297,11 @@ func NewReporter(opts Options) Reporter {
 			//      this message as a concrete error type (it uses fmt.Errorf),
 			//      we need to check the error message.
 			if strings.Contains(err.Error(), "previously registered") {
-				err = errors.WithMessagef(
-					err,
+				err = fmt.Errorf(
 					"potential tally.Scope() vs Prometheus usage contract mismatch: "+
 						"if this occurs after using Scope.Tagged(), different metric "+
-						"names must be used than were registered with the parent scope",
+						"names must be used than were registered with the parent scope: %w",
+					err,
 				)
 			}
 


### PR DESCRIPTION
There are only two places in this library where github.com/pkg/errors is used, and in both cases this functionality can be replaced by using standard library facilities. I suspect this library was introduced by mistake. This change replaces the two uses of that library with calls to `fmt.Errorf()` using `%w` to wrap the underlying error and to respect the same semantics of the functions that were previously used.