### PR TITLE
redact host and instance tags for internal metrics

### DIFF
--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -66,6 +66,8 @@ const (
 	DefaultHistogramBucketIDName = "bucketid"
 	// DefaultHistogramBucketName is the default histogram bucket name tag name
 	DefaultHistogramBucketName = "bucket"
+	// DefaultTagRedactValue is the default tag value to use when redacting
+	DefaultTagRedactValue = "global"
 	// DefaultHistogramBucketTagPrecision is the default
 	// precision to use when formatting the metric tag
 	// with the histogram bucket bound values.
@@ -287,7 +289,9 @@ func NewReporter(opts Options) (Reporter, error) {
 	}
 
 	internalTags := map[string]string{
-		"version": tally.Version,
+		"version":  tally.Version,
+		"host":     DefaultTagRedactValue,
+		"instance": DefaultTagRedactValue,
 	}
 
 	for k, v := range opts.InternalTags {

--- a/m3/reporter_test.go
+++ b/m3/reporter_test.go
@@ -599,15 +599,18 @@ func TestReporterCommmonTagsInternal(t *testing.T) {
 			for k, v := range internalTags {
 				require.True(t, tagEquals(metric.Tags, k, v))
 			}
+
+			// The following tags should be redacted.
+			require.True(t, tagEquals(metric.Tags, "host", DefaultTagRedactValue))
+			require.True(t, tagEquals(metric.Tags, "instance", DefaultTagRedactValue))
 		} else {
 			require.Equal(t, "testCounter1", metric.Name)
 			require.False(t, tagIncluded(metric.Tags, "internal1"))
 			require.False(t, tagIncluded(metric.Tags, "internal2"))
 		}
+
 		// The following tags should not be present as part of the individual metrics
 		// as they are common tags.
-		require.False(t, tagIncluded(metric.Tags, "host"))
-		require.False(t, tagIncluded(metric.Tags, "instance"))
 		require.False(t, tagIncluded(metric.Tags, "service"))
 	}
 	require.Equal(t, internalMetrics, numInternalMetricsActual)


### PR DESCRIPTION
We want to avoid high cardinality on internal metrics due to host and instance tags.