### PR TITLE
Revise internal cardinality metrics

### DIFF
--- a/m3/example/m3_main.go
+++ b/m3/example/m3_main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -87,7 +87,8 @@ func main() {
 	}
 
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{
-		CachedReporter: r,
+		CachedReporter:         r,
+		CardinalityMetricsTags: cfg.M3.InternalTags,
 	}, 1*time.Second)
 
 	defer closer.Close()

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -66,8 +66,6 @@ const (
 	DefaultHistogramBucketIDName = "bucketid"
 	// DefaultHistogramBucketName is the default histogram bucket name tag name
 	DefaultHistogramBucketName = "bucket"
-	// DefaultTagRedactValue is the default tag value to use when redacting
-	DefaultTagRedactValue = "global"
 	// DefaultHistogramBucketTagPrecision is the default
 	// precision to use when formatting the metric tag
 	// with the histogram bucket bound values.
@@ -290,8 +288,8 @@ func NewReporter(opts Options) (Reporter, error) {
 
 	internalTags := map[string]string{
 		"version":  tally.Version,
-		"host":     DefaultTagRedactValue,
-		"instance": DefaultTagRedactValue,
+		"host":     tally.DefaultTagRedactValue,
+		"instance": tally.DefaultTagRedactValue,
 	}
 
 	for k, v := range opts.InternalTags {

--- a/m3/reporter_integration_test.go
+++ b/m3/reporter_integration_test.go
@@ -55,6 +55,7 @@ func main() {
 
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{
 		CachedReporter: r,
+		OmitCardinalityMetrics: true,
 	}, 5 * time.Second)
 	defer closer.Close()
 

--- a/m3/reporter_test.go
+++ b/m3/reporter_test.go
@@ -57,7 +57,7 @@ var (
 var protocols = []Protocol{Compact, Binary}
 
 const internalMetrics = 5    // Additional metrics the reporter sends in a batch - use this, not a magic number.
-const cardinalityMetrics = 3 // Additional metrics emitted by the scope registry.
+const cardinalityMetrics = 4 // Additional metrics emitted by the scope registry.
 
 // TestReporter tests the reporter works as expected with both compact and binary protocols
 func TestReporter(t *testing.T) {
@@ -601,8 +601,8 @@ func TestReporterCommmonTagsInternal(t *testing.T) {
 			}
 
 			// The following tags should be redacted.
-			require.True(t, tagEquals(metric.Tags, "host", DefaultTagRedactValue))
-			require.True(t, tagEquals(metric.Tags, "instance", DefaultTagRedactValue))
+			require.True(t, tagEquals(metric.Tags, "host", tally.DefaultTagRedactValue))
+			require.True(t, tagEquals(metric.Tags, "instance", tally.DefaultTagRedactValue))
 		} else {
 			require.Equal(t, "testCounter1", metric.Name)
 			require.False(t, tagIncluded(metric.Tags, "internal1"))

--- a/m3/scope_test.go
+++ b/m3/scope_test.go
@@ -50,10 +50,10 @@ func newTestReporterScope(
 	require.NoError(t, err)
 
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{
-		Prefix:         scopePrefix,
-		Tags:           scopeTags,
-		CachedReporter: r,
-		MetricsOption:  tally.SendInternalMetrics,
+		Prefix:                 scopePrefix,
+		Tags:                   scopeTags,
+		CachedReporter:         r,
+		OmitCardinalityMetrics: false,
 	}, shortInterval)
 
 	return r, scope, func() {

--- a/scope.go
+++ b/scope.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Uber Technologies, Inc.
+// Copyright (c) 2024 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,17 +28,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-// InternalMetricOption is used to configure internal metrics.
-type InternalMetricOption int
-
 const (
-	// Unset is the "no-op" config, which turns off internal metrics.
-	Unset InternalMetricOption = iota
-	// SendInternalMetrics turns on internal metrics submission.
-	SendInternalMetrics
-	// OmitInternalMetrics turns off internal metrics submission.
-	OmitInternalMetrics
-
 	_defaultInitialSliceSize  = 16
 	_defaultReportingInterval = 2 * time.Second
 )
@@ -106,15 +96,16 @@ type scope struct {
 
 // ScopeOptions is a set of options to construct a scope.
 type ScopeOptions struct {
-	Tags               map[string]string
-	Prefix             string
-	Reporter           StatsReporter
-	CachedReporter     CachedStatsReporter
-	Separator          string
-	DefaultBuckets     Buckets
-	SanitizeOptions    *SanitizeOptions
-	registryShardCount uint
-	MetricsOption      InternalMetricOption
+	Tags                   map[string]string
+	Prefix                 string
+	Reporter               StatsReporter
+	CachedReporter         CachedStatsReporter
+	Separator              string
+	DefaultBuckets         Buckets
+	SanitizeOptions        *SanitizeOptions
+	registryShardCount     uint
+	OmitCardinalityMetrics bool
+	CardinalityMetricsTags map[string]string
 }
 
 // NewRootScope creates a new root Scope with a set of options and
@@ -190,7 +181,7 @@ func newRootScope(opts ScopeOptions, interval time.Duration) *scope {
 	s.tags = s.copyAndSanitizeMap(opts.Tags)
 
 	// Register the root scope
-	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.MetricsOption)
+	s.registry = newScopeRegistryWithShardCount(s, opts.registryShardCount, opts.OmitCardinalityMetrics, opts.CardinalityMetricsTags)
 
 	if interval > 0 {
 		s.wg.Add(1)

--- a/scope_registry.go
+++ b/scope_registry.go
@@ -36,7 +36,7 @@ var (
 	counterCardinalityName   = "tally.internal.counter_cardinality"
 	gaugeCardinalityName     = "tally.internal.gauge_cardinality"
 	histogramCardinalityName = "tally.internal.histogram_cardinality"
-	scopeCardinalityName     = "tally.internal.scope_cardinality"
+	scopeCardinalityName     = "tally.internal.num_active_scopes"
 )
 
 const (

--- a/scope_test.go
+++ b/scope_test.go
@@ -360,7 +360,7 @@ func (r *testStatsReporter) Flush() {
 
 func TestWriteTimerImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	s.Timer("ticky").Record(time.Millisecond * 175)
@@ -369,7 +369,7 @@ func TestWriteTimerImmediately(t *testing.T) {
 
 func TestWriteTimerClosureImmediately(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 	r.tg.Add(1)
 	tm := s.Timer("ticky")
@@ -379,7 +379,7 @@ func TestWriteTimerClosureImmediately(t *testing.T) {
 
 func TestWriteReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 10)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -398,7 +398,7 @@ func TestWriteReportLoop(t *testing.T) {
 func TestWriteReportLoopDefaultInterval(t *testing.T) {
 	r := newTestStatsReporter()
 	s, closer := NewRootScopeWithDefaultInterval(
-		ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics},
+		ScopeOptions{Reporter: r, OmitCardinalityMetrics: true},
 	)
 	defer closer.Close()
 
@@ -417,7 +417,7 @@ func TestWriteReportLoopDefaultInterval(t *testing.T) {
 
 func TestCachedReportLoop(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}, 10)
+	s, closer := NewRootScope(ScopeOptions{CachedReporter: r, OmitCardinalityMetrics: true}, 10)
 	defer closer.Close()
 
 	r.cg.Add(1)
@@ -435,9 +435,9 @@ func TestCachedReportLoop(t *testing.T) {
 func testReportLoopFlushOnce(t *testing.T, cached bool) {
 	r := newTestStatsReporter()
 
-	scopeOpts := ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}
+	scopeOpts := ScopeOptions{CachedReporter: r, OmitCardinalityMetrics: true}
 	if !cached {
-		scopeOpts = ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}
+		scopeOpts = ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}
 	}
 
 	s, closer := NewRootScope(scopeOpts, 10*time.Minute)
@@ -475,7 +475,7 @@ func TestReporterFlushOnce(t *testing.T) {
 func TestWriteOnce(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -546,10 +546,10 @@ func TestHistogramSharedBucketMetrics(t *testing.T) {
 	var (
 		r     = newTestStatsReporter()
 		scope = newRootScope(ScopeOptions{
-			Prefix:         "",
-			Tags:           nil,
-			CachedReporter: r,
-			MetricsOption:  OmitInternalMetrics,
+			Prefix:                 "",
+			Tags:                   nil,
+			CachedReporter:         r,
+			OmitCardinalityMetrics: true,
 		}, 0)
 		builder = func(s Scope) func(map[string]string) {
 			buckets := MustMakeLinearValueBuckets(10, 10, 3)
@@ -620,10 +620,10 @@ func TestConcurrentUpdates(t *testing.T) {
 		counterIncrs     = 5000
 		rs               = newRootScope(
 			ScopeOptions{
-				Prefix:         "",
-				Tags:           nil,
-				CachedReporter: r,
-				MetricsOption:  OmitInternalMetrics,
+				Prefix:                 "",
+				Tags:                   nil,
+				CachedReporter:         r,
+				OmitCardinalityMetrics: true,
 			}, 0,
 		)
 		scopes   = []Scope{rs}
@@ -669,9 +669,9 @@ func TestCounterSanitized(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(ScopeOptions{
-		Reporter:        r,
-		SanitizeOptions: &alphanumericSanitizerOpts,
-		MetricsOption:   OmitInternalMetrics,
+		Reporter:               r,
+		SanitizeOptions:        &alphanumericSanitizerOpts,
+		OmitCardinalityMetrics: true,
 	}, 0)
 	defer closer.Close()
 
@@ -727,7 +727,7 @@ func TestCounterSanitized(t *testing.T) {
 func TestCachedReporter(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{CachedReporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -764,7 +764,7 @@ func TestCachedReporter(t *testing.T) {
 func TestRootScopeWithoutPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -799,7 +799,7 @@ func TestRootScopeWithPrefix(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(
-		ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0,
+		ScopeOptions{Prefix: "foo", Reporter: r, OmitCardinalityMetrics: true}, 0,
 	)
 	defer closer.Close()
 
@@ -836,7 +836,7 @@ func TestRootScopeWithDifferentSeparator(t *testing.T) {
 
 	root, closer := NewRootScope(
 		ScopeOptions{
-			Prefix: "foo", Separator: "_", Reporter: r, MetricsOption: OmitInternalMetrics,
+			Prefix: "foo", Separator: "_", Reporter: r, OmitCardinalityMetrics: true,
 		}, 0,
 	)
 	defer closer.Close()
@@ -873,7 +873,7 @@ func TestSubScope(t *testing.T) {
 	r := newTestStatsReporter()
 
 	root, closer := NewRootScope(
-		ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0,
+		ScopeOptions{Prefix: "foo", Reporter: r, OmitCardinalityMetrics: true}, 0,
 	)
 	defer closer.Close()
 
@@ -916,7 +916,7 @@ func TestSubScope(t *testing.T) {
 func TestSubScopeClose(t *testing.T) {
 	r := newTestStatsReporter()
 
-	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	rs, closer := NewRootScope(ScopeOptions{Prefix: "foo", Reporter: r, OmitCardinalityMetrics: true}, 0)
 	// defer closer.Close()
 	_ = closer
 
@@ -1009,7 +1009,7 @@ func TestTaggedSubScope(t *testing.T) {
 	ts := map[string]string{"env": "test"}
 	root, closer := NewRootScope(
 		ScopeOptions{
-			Prefix: "foo", Tags: ts, Reporter: r, MetricsOption: OmitInternalMetrics,
+			Prefix: "foo", Tags: ts, Reporter: r, OmitCardinalityMetrics: true,
 		}, 0,
 	)
 	defer closer.Close()
@@ -1067,11 +1067,11 @@ func TestTaggedSanitizedSubScope(t *testing.T) {
 
 	ts := map[string]string{"env": "test:env"}
 	root, closer := NewRootScope(ScopeOptions{
-		Prefix:          "foo",
-		Tags:            ts,
-		Reporter:        r,
-		SanitizeOptions: &alphanumericSanitizerOpts,
-		MetricsOption:   OmitInternalMetrics,
+		Prefix:                 "foo",
+		Tags:                   ts,
+		Reporter:               r,
+		SanitizeOptions:        &alphanumericSanitizerOpts,
+		OmitCardinalityMetrics: true,
 	}, 0)
 	defer closer.Close()
 	s := root.(*scope)
@@ -1104,7 +1104,7 @@ func TestTaggedExistingReturnsSameScope(t *testing.T) {
 	} {
 		root, closer := NewRootScope(
 			ScopeOptions{
-				Prefix: "foo", Tags: initialTags, Reporter: r, MetricsOption: OmitInternalMetrics,
+				Prefix: "foo", Tags: initialTags, Reporter: r, OmitCardinalityMetrics: true,
 			}, 0,
 		)
 		defer closer.Close()
@@ -1224,7 +1224,7 @@ func TestSnapshotConcurrent(t *testing.T) {
 
 func TestCapabilities(t *testing.T) {
 	r := newTestStatsReporter()
-	s, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	s, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 	assert.True(t, s.Capabilities().Reporting())
 	assert.False(t, s.Capabilities().Tagging())
@@ -1252,8 +1252,8 @@ func TestScopeDefaultBuckets(t *testing.T) {
 			90 * time.Millisecond,
 			120 * time.Millisecond,
 		},
-		Reporter:      r,
-		MetricsOption: OmitInternalMetrics,
+		Reporter:               r,
+		OmitCardinalityMetrics: true,
 	}, 0)
 	defer closer.Close()
 
@@ -1284,7 +1284,7 @@ func newTestMets(scope Scope) testMets {
 func TestReturnByValue(t *testing.T) {
 	r := newTestStatsReporter()
 
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 	defer closer.Close()
 
 	s := root.(*scope)
@@ -1301,7 +1301,7 @@ func TestReturnByValue(t *testing.T) {
 
 func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, 0)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, 0)
 
 	s := root.(*scope)
 	s.reportLoopRun()
@@ -1316,7 +1316,7 @@ func TestScopeAvoidReportLoopRunOnClose(t *testing.T) {
 
 func TestScopeFlushOnClose(t *testing.T) {
 	r := newTestStatsReporter()
-	root, closer := NewRootScope(ScopeOptions{Reporter: r, MetricsOption: OmitInternalMetrics}, time.Hour)
+	root, closer := NewRootScope(ScopeOptions{Reporter: r, OmitCardinalityMetrics: true}, time.Hour)
 
 	r.cg.Add(1)
 	root.Counter("foo").Inc(1)


### PR DESCRIPTION
This revises what and how cardinality metrics are reported.

Changes:

- Cardinality data is emitted by default, as Gauge
- Names are now prefixed `tally.internal.` to be consistent with others
- Added scope cardinality data
- Cardinality metrics' tags are now consistent with reporter internal metrics