### PR TITLE
do not allocate gauge if cardinality metrics are turned off

### DIFF
--- a/scope_registry.go
+++ b/scope_registry.go
@@ -103,7 +103,7 @@ func newScopeRegistryWithShardCount(
 		}
 		r.subscopes[i].s[scopeRegistryKey(root.prefix, root.tags)] = root
 	}
-	if r.root.cachedReporter != nil {
+	if r.root.cachedReporter != nil && !omitCardinalityMetrics {
 		r.cachedCounterCardinalityGauge = r.root.cachedReporter.AllocateGauge(r.sanitizedCounterCardinalityName, r.cardinalityMetricsTags)
 		r.cachedGaugeCardinalityGauge = r.root.cachedReporter.AllocateGauge(r.sanitizedGaugeCardinalityName, r.cardinalityMetricsTags)
 		r.cachedHistogramCardinalityGauge = r.root.cachedReporter.AllocateGauge(r.sanitizedHistogramCardinalityName, r.cardinalityMetricsTags)


### PR DESCRIPTION
Changes:
- Cached gauges will not be allocated if omitCardinalityMetrics is set to true