### PR TITLE
prevent race condition when reading from counters slice

### DIFF
--- a/scope_registry.go
+++ b/scope_registry.go
@@ -309,6 +309,8 @@ func (r *scopeRegistry) reportInternalMetrics() {
 	scopes.Inc() // Account for root scope.
 	r.ForEachScope(
 		func(ss *scope) {
+			ss.cm.RLock()
+			defer ss.cm.RUnlock()
 			counterSliceLen, gaugeSliceLen, histogramSliceLen := int64(len(ss.countersSlice)), int64(len(ss.gaugesSlice)), int64(len(ss.histogramsSlice))
 			if ss.root { // Root scope is referenced across all buckets.
 				rootCounters.Store(counterSliceLen)


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c000002568 by goroutine 13:
  github.com/uber-go/tally/v4.(*scopeRegistry).reportInternalMetrics.func1()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope_registry.go:312 +0x89
  github.com/uber-go/tally/v4.(*scopeRegistry).ForEachScope()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope_registry.go:159 +0x141
  github.com/uber-go/tally/v4.(*scopeRegistry).reportInternalMetrics()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope_registry.go:310 +0x309
  github.com/uber-go/tally/v4.(*scopeRegistry).CachedReport()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope_registry.go:137 +0x9c
  github.com/uber-go/tally/v4.(*scope).reportRegistry()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope.go:278 +0xdc
  github.com/uber-go/tally/v4.(*scope).reportLoopRun()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope.go:270 +0x4e
  github.com/uber-go/tally/v4.(*scope).reportLoop()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope.go:258 +0xc5
  github.com/uber-go/tally/v4.newRootScope.func1()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope.go:198 +0xa4


Previous write at 0x00c000002568 by goroutine 77:
  github.com/uber-go/tally/v4.(*scope).Counter()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/uber-go/tally/v4/scope.go:306 +0x4e5
  github.com/go-chi/telemetry.(*Scope).RecordHit()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/go-chi/telemetry/telemetry.go:74 +0xaf
  github.com/go-chi/telemetry.sample()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/go-chi/telemetry/http.go:29 +0x51d
  github.com/go-chi/telemetry.Collector.func4.1.1()
      /home/lukas-jenicek/Projects/Horizon/stack/vendor/github.com/go-chi/telemetry/collector.go:94 +0x79
  runtime.deferreturn()
```

Test cases needs to be done.