### PR TITLE
Update README.md to use v4 in go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Fast, buffered, hierarchical stats collection in Go.
 
 ## Installation
-`go get -u github.com/uber-go/tally`
+`go get -u github.com/uber-go/tally/v4`
 
 ## Abstract
 


### PR DESCRIPTION
https://go.dev/ref/mod#module-path

The command that mentioned in the readme actually will download v3 of the package. Is it intentional?
```
$ go get -u github.com/uber-go/tally
...
go: added github.com/uber-go/tally v3.5.10+incompatible
```
