### PR TITLE
Add empty check before accessing buffer `dumpcontext` and `parseContextStack`

### DIFF
--- a/thirdparty/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
+++ b/thirdparty/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
@@ -565,6 +565,10 @@ func (p *TSimpleJSONProtocol) Transport() TTransport {
 }
 
 func (p *TSimpleJSONProtocol) OutputPreValue() error {
+	if len(p.dumpContext) == 0 {
+		return errors.New("dumpContext is empty")
+	}
+
 	cxt := _ParseContext(p.dumpContext[len(p.dumpContext)-1])
 	switch cxt {
 	case _CONTEXT_IN_LIST, _CONTEXT_IN_OBJECT_NEXT_KEY:
@@ -582,6 +586,10 @@ func (p *TSimpleJSONProtocol) OutputPreValue() error {
 }
 
 func (p *TSimpleJSONProtocol) OutputPostValue() error {
+	if len(p.dumpContext) == 0 {
+        return errors.New("dumpContext is empty")
+    }
+
 	cxt := _ParseContext(p.dumpContext[len(p.dumpContext)-1])
 	switch cxt {
 	case _CONTEXT_IN_LIST_FIRST:
@@ -608,6 +616,10 @@ func (p *TSimpleJSONProtocol) OutputBool(value bool) error {
 	if e := p.OutputPreValue(); e != nil {
 		return e
 	}
+	if len(p.dumpContext) == 0 {
+		return errors.New("dumpContext is empty")
+	}
+
 	var v string
 	if value {
 		v = string(JSON_TRUE)
@@ -648,6 +660,9 @@ func (p *TSimpleJSONProtocol) OutputF64(value float64) error {
 		v = string(JSON_QUOTE) + JSON_NEGATIVE_INFINITY + string(JSON_QUOTE)
 	} else {
 		v = strconv.FormatFloat(value, 'g', -1, 64)
+		if len(p.dumpContext) == 0 {
+			return errors.New("dumpContext is empty")
+		}
 		switch _ParseContext(p.dumpContext[len(p.dumpContext)-1]) {
 		case _CONTEXT_IN_OBJECT_FIRST, _CONTEXT_IN_OBJECT_NEXT_KEY:
 			v = string(JSON_QUOTE) + v + string(JSON_QUOTE)
@@ -664,6 +679,10 @@ func (p *TSimpleJSONProtocol) OutputI64(value int64) error {
 	if e := p.OutputPreValue(); e != nil {
 		return e
 	}
+	if len(p.dumpContext) == 0 {
+		return errors.New("dumpContext is empty")
+	}
+
 	v := strconv.FormatInt(value, 10)
 	switch _ParseContext(p.dumpContext[len(p.dumpContext)-1]) {
 	case _CONTEXT_IN_OBJECT_FIRST, _CONTEXT_IN_OBJECT_NEXT_KEY:
@@ -706,6 +725,10 @@ func (p *TSimpleJSONProtocol) OutputObjectEnd() error {
 	if _, e := p.write(JSON_RBRACE); e != nil {
 		return NewTProtocolException(e)
 	}
+	if len(p.dumpContext) == 0 {
+        return errors.New("dumpContext is empty")
+    }
+
 	p.dumpContext = p.dumpContext[:len(p.dumpContext)-1]
 	if e := p.OutputPostValue(); e != nil {
 		return e
@@ -728,6 +751,10 @@ func (p *TSimpleJSONProtocol) OutputListEnd() error {
 	if _, e := p.write(JSON_RBRACKET); e != nil {
 		return NewTProtocolException(e)
 	}
+	if len(p.dumpContext) == 0 {
+        return errors.New("dumpContext is empty")
+    }
+
 	p.dumpContext = p.dumpContext[:len(p.dumpContext)-1]
 	if e := p.OutputPostValue(); e != nil {
 		return e
@@ -752,6 +779,10 @@ func (p *TSimpleJSONProtocol) ParsePreValue() error {
 	if e := p.readNonSignificantWhitespace(); e != nil {
 		return NewTProtocolException(e)
 	}
+	if len(p.parseContextStack) == 0 {
+		return errors.New("parseContextStack is empty")
+	}
+
 	cxt := _ParseContext(p.parseContextStack[len(p.parseContextStack)-1])
 	b, _ := p.reader.Peek(1)
 	switch cxt {
@@ -812,6 +843,10 @@ func (p *TSimpleJSONProtocol) ParsePostValue() error {
 	if e := p.readNonSignificantWhitespace(); e != nil {
 		return NewTProtocolException(e)
 	}
+	if len(p.parseContextStack) == 0 {
+        return errors.New("parseContextStack is empty")
+    }
+
 	cxt := _ParseContext(p.parseContextStack[len(p.parseContextStack)-1])
 	switch cxt {
 	case _CONTEXT_IN_LIST_FIRST:
@@ -991,6 +1026,10 @@ func (p *TSimpleJSONProtocol) ParseObjectEnd() error {
 	if isNull, err := p.readIfNull(); isNull || err != nil {
 		return err
 	}
+	if len(p.parseContextStack) == 0 {
+		return errors.New("parseContextStack is empty")
+	}
+
 	cxt := _ParseContext(p.parseContextStack[len(p.parseContextStack)-1])
 	if (cxt != _CONTEXT_IN_OBJECT_FIRST) && (cxt != _CONTEXT_IN_OBJECT_NEXT_KEY) {
 		e := fmt.Errorf("Expected to be in the Object Context, but not in Object Context (%d)", cxt)
@@ -1052,6 +1091,10 @@ func (p *TSimpleJSONProtocol) ParseListEnd() error {
 	if isNull, err := p.readIfNull(); isNull || err != nil {
 		return err
 	}
+	if len(p.parseContextStack) == 0 {
+		return errors.New("parseContextStack is empty")
+	}
+
 	cxt := _ParseContext(p.parseContextStack[len(p.parseContextStack)-1])
 	if cxt != _CONTEXT_IN_LIST {
 		e := fmt.Errorf("Expected to be in the List Context, but not in List Context (%d)", cxt)


### PR DESCRIPTION
**Description:**

This PR introduces additional checks in several functions within `simple_json_protocol.go` to ensure that `dumpContext` and `parseContextStack` are not used in the slicing or accessed in the buffer access operation when they are empty.

**Impact:**

This patch does not alter existing logic but rather introduces defensive checks to make the project more predictable and resilient. In total, there are 21 slicing and buffer access upon `dumpcontext` and `parseContextStack`. In this way, potential bof(Buffer-Overflow) panic can be avoided. We believe these changes align with best practices for defensive programming and may help streamline debugging and future development.

Looking forward to your feedback, and happy to refine the changes if needed. Thanks! 