### PR TITLE
Fix duration buckets overflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,11 @@ on:
 jobs:
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go: ["stable", "oldstable"]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm"]
 
     steps:
     - name: Checkout code

--- a/histogram.go
+++ b/histogram.go
@@ -307,8 +307,9 @@ func LinearDurationBuckets(start, width time.Duration, n int) (DurationBuckets, 
 		return nil, errBucketsCountNeedsGreaterThanZero
 	}
 	buckets := make([]time.Duration, n)
-	for i := range buckets {
-		buckets[i] = start + (time.Duration(i) * width)
+	buckets[0] = start
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = safeDurationSum(buckets[i-1], width)
 	}
 	return buckets, nil
 }

--- a/histogram.go
+++ b/histogram.go
@@ -368,7 +368,7 @@ func ExponentialDurationBuckets(start time.Duration, factor float64, n int) (Dur
 	curr := start
 	for i := range buckets {
 		buckets[i] = curr
-		curr = time.Duration(float64(curr) * factor)
+		curr = time.Duration(safeFloat64ToInt64(float64(curr) * factor))
 	}
 	return buckets, nil
 }

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func parseDuration(s string) time.Duration {
+	duration, _ := time.ParseDuration(s)
+	return duration
+}
+
 func TestValueBucketsString(t *testing.T) {
 	result, err := LinearValueBuckets(1, 1, 3)
 	require.NoError(t, err)
@@ -46,6 +51,12 @@ func TestDurationBucketsOverflowString(t *testing.T) {
 	result, err := LinearDurationBuckets(maxDuration-(2*time.Second), time.Second, 4)
 	require.NoError(t, err)
 	assert.Equal(t, "[2562047h47m14.854775807s 2562047h47m15.854775807s 2562047h47m16.854775807s 2562047h47m16.854775807s]", Buckets(result).String())
+}
+
+func TestExponentialDurationBucketsOverflowString(t *testing.T) {
+	result, err := ExponentialDurationBuckets(parseDuration("1749144h56m16.554119168s"), 1.3, 4)
+	require.NoError(t, err)
+	assert.Equal(t, "[1749144h56m16.554119168s 2273888h25m9.520355328s 2562047h47m16.854775807s 2562047h47m16.854775807s]", Buckets(result).String())
 }
 
 func TestBucketPairsDefaultsToNegInfinityToInfinity(t *testing.T) {
@@ -178,6 +189,32 @@ func TestMustMakeExponentialDurationBucketsOverflow(t *testing.T) {
 		assert.Equal(t, DurationBuckets{
 			math.MaxInt64 * time.Nanosecond, math.MaxInt64 * time.Nanosecond, math.MaxInt64 * time.Nanosecond,
 		}, MustMakeExponentialDurationBuckets(math.MaxInt64*time.Nanosecond, 2, 3))
+	})
+	assert.NotPanics(t, func() {
+		assert.Equal(t, DurationBuckets{
+			parseDuration("471095h35m13.288997632s"),
+			parseDuration("612424h15m47.275696896s"),
+			parseDuration("796151h32m31.458405888s"),
+			parseDuration("1034997h0m16.895927808s"),
+			parseDuration("1345496h6m21.964706816s"),
+			parseDuration("1749144h56m16.554119168s"),
+			parseDuration("2273888h25m9.520355328s"),
+			parseDuration("2562047h47m16.854775807s"),
+			parseDuration("2562047h47m16.854775807s"),
+		}, MustMakeExponentialDurationBuckets(parseDuration("471095h35m13.288997632s"), 1.3, 9))
+	})
+}
+
+func TestMustMakeLinearDurationBucketsOverflow(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.Equal(t, DurationBuckets{
+			parseDuration("0s"),
+			parseDuration("1281023h53m38.427387903s"),
+			parseDuration("2562047h47m16.854775806s"),
+			parseDuration("2562047h47m16.854775807s"),
+			parseDuration("2562047h47m16.854775807s"),
+			parseDuration("2562047h47m16.854775807s"),
+		}, MustMakeLinearDurationBuckets(0, time.Duration(math.MaxInt64/2), 6))
 	})
 }
 

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -41,6 +41,13 @@ func TestDurationBucketsString(t *testing.T) {
 	assert.Equal(t, "[1s 2s 3s]", Buckets(result).String())
 }
 
+func TestDurationBucketsOverflowString(t *testing.T) {
+	maxDuration := time.Duration(math.MaxInt64)
+	result, err := LinearDurationBuckets(maxDuration-(2*time.Second), time.Second, 4)
+	require.NoError(t, err)
+	assert.Equal(t, "[2562047h47m14.854775807s 2562047h47m15.854775807s 2562047h47m16.854775807s 2562047h47m16.854775807s]", Buckets(result).String())
+}
+
 func TestBucketPairsDefaultsToNegInfinityToInfinity(t *testing.T) {
 	pairs := BucketPairs(nil)
 	require.Equal(t, 1, len(pairs))

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -166,6 +166,14 @@ func TestMustMakeExponentialDurationBucketsPanicsOnBadFactor(t *testing.T) {
 	})
 }
 
+func TestMustMakeExponentialDurationBucketsOverflow(t *testing.T) {
+	assert.NotPanics(t, func() {
+		assert.Equal(t, DurationBuckets{
+			math.MaxInt64 * time.Nanosecond, math.MaxInt64 * time.Nanosecond, math.MaxInt64 * time.Nanosecond,
+		}, MustMakeExponentialDurationBuckets(math.MaxInt64*time.Nanosecond, 2, 3))
+	})
+}
+
 func TestBucketPairsNoRaceWhenSorted(t *testing.T) {
 	buckets := DurationBuckets{}
 	for i := 0; i < 99; i++ {

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,7 @@ package tally
 
 import (
 	"math"
+	"time"
 )
 
 func safeFloat64ToInt64(v float64) int64 {
@@ -32,4 +33,16 @@ func safeFloat64ToInt64(v float64) int64 {
 		return math.MinInt64
 	}
 	return int64(v)
+}
+
+func safeDurationSum(a, b time.Duration) time.Duration {
+	sum := a + b
+	switch {
+	case b > 0 && sum < a: // Overflow
+		return time.Duration(math.MaxInt64)
+	case b < 0 && sum > a: // Underflow
+		return time.Duration(math.MinInt64)
+	default:
+		return sum
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+import (
+	"math"
+)
+
+func safeFloat64ToInt64(v float64) int64 {
+	if v >= float64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	if v <= float64(math.MinInt64) {
+		return math.MinInt64
+	}
+	return int64(v)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -23,6 +23,7 @@ package tally
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +31,19 @@ import (
 func TestSafeFloat64ToInt64(t *testing.T) {
 	assert.Equal(t, int64(math.MaxInt64), safeFloat64ToInt64(float64(math.MaxInt64)*2))
 	assert.Equal(t, int64(math.MaxInt64), safeFloat64ToInt64(float64(math.MaxInt64)+1000))
+
 	assert.Equal(t, int64(math.MinInt64), safeFloat64ToInt64(float64(math.MinInt64)*2))
 	assert.Equal(t, int64(math.MinInt64), safeFloat64ToInt64(float64(math.MinInt64)-1000))
+
 	assert.Equal(t, int64(1000), safeFloat64ToInt64(1000))
+}
+
+func TestSafeDurationSum(t *testing.T) {
+	maxDuration := time.Duration(math.MaxInt64)
+	assert.Equal(t, maxDuration, safeDurationSum(maxDuration, 1))
+
+	minDuration := time.Duration(math.MinInt64)
+	assert.Equal(t, minDuration, safeDurationSum(minDuration, -1))
+
+	assert.Equal(t, 10*time.Second, safeDurationSum(3*time.Second, 7*time.Second))
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeFloat64ToInt64(t *testing.T) {
+	assert.Equal(t, int64(math.MaxInt64), safeFloat64ToInt64(float64(math.MaxInt64)*2))
+	assert.Equal(t, int64(math.MaxInt64), safeFloat64ToInt64(float64(math.MaxInt64)+1000))
+	assert.Equal(t, int64(math.MinInt64), safeFloat64ToInt64(float64(math.MinInt64)*2))
+	assert.Equal(t, int64(math.MinInt64), safeFloat64ToInt64(float64(math.MinInt64)-1000))
+	assert.Equal(t, int64(1000), safeFloat64ToInt64(1000))
+}


### PR DESCRIPTION
Fix for #264 
This PR addresses an overflow issue in `ExponentialDurationBuckets`, which can cause negative durations due to integer wrap-around when converting large values into `time.Duration`.

### Problem
Under the hood, `time.Duration` is represented as an `int64` nanosecond value. When the exponential scaling factor produces a number too large for `int64`, an overflow occurs, resulting in buckets with negative durations on some architectures.

Example:
```
tally.ExponentialDurationBuckets(time.Second, 1.3, 90)
```
Results in:
**x86**: `[..., -2562047h47m16.854775808s, -2562047h47m16.854775808s]`
**ARM**: `[..., 2562047h47m16.854775807s, 2562047h47m16.854775807s]`
(ARM seems to perform saturating calculations instead of wrapping.)

### Solution
This PR introduces a `safeFloat64ToInt64` function, which checks for overflows before converting to `time.Duration`. If an overflow is detected, it returns `math.MinInt64` or `math.MaxInt64`, preventing undefined behavior.

Now, `ExponentialDurationBuckets` will still return identical buckets in case of overflow, but the behavior will be consistent across different CPU architectures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the logic for generating duration buckets, improving precision and handling of extreme input values.

- **Bug Fixes**
  - Added tests to ensure that the system behaves correctly under maximum limit conditions, preventing unexpected errors.

- **Tests**
  - Introduced new test functions to validate the behavior of duration calculations and conversions, enhancing overall test coverage.

- **Chores**
  - Updated the workflow configuration to support testing across multiple operating systems, improving testing flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->