### PR TITLE
chore: allow dashes and dots in the metric label values

### DIFF
--- a/prometheus/sanitize.go
+++ b/prometheus/sanitize.go
@@ -35,7 +35,7 @@ var DefaultSanitizerOpts = tally.SanitizeOptions{
 		Characters: tally.UnderscoreCharacters,
 	},
 	ValueCharacters: tally.ValidCharacters{
-		Ranges:     tally.AlphanumericRange,
+		Ranges:     append(tally.AlphanumericRange, tally.SanitizeRange{rune('-'), rune('.')}),
 		Characters: tally.UnderscoreCharacters,
 	},
 	ReplacementCharacter: tally.DefaultReplacementCharacter,


### PR DESCRIPTION
The Prometheus Data model allows any unicode characters in label values, as documented [here](https://prometheus.io/docs/concepts/data_model/\#:\~:text\=Label%20values%20may%20contain%20any%20Unicode%20characters.)