### PR TITLE
fix: prevent panic in histogram RecordValue for NaN and +Inf

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -376,6 +376,10 @@ func (h *histogram) RecordValue(value float64) {
 	idx := sort.Search(len(h.buckets), func(i int) bool {
 		return h.buckets[i].valueUpperBound >= value
 	})
+	if idx == len(h.buckets) {
+		// value is NaN or +Inf, neither of which compares as <= any bound.
+		idx = len(h.buckets) - 1
+	}
 	h.samples[idx].counter.Inc(1)
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -21,6 +21,7 @@
 package tally
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -145,6 +146,18 @@ func TestHistogramValueSamples(t *testing.T) {
 	assert.Equal(t, 3, r.valueSamples[10.0])
 	assert.Equal(t, 5, r.valueSamples[60.0])
 	assert.Equal(t, buckets, r.buckets)
+}
+
+func TestHistogramRecordValueNonComparable(t *testing.T) {
+	r := newStatsTestReporter()
+	buckets := MustMakeLinearValueBuckets(0, 10, 10)
+	storage := newBucketStorage(valueHistogramType, buckets)
+	h := newHistogram(valueHistogramType, "h1", nil, r, storage, nil)
+
+	assert.NotPanics(t, func() {
+		h.RecordValue(math.NaN())
+		h.RecordValue(math.Inf(1))
+	})
 }
 
 func TestHistogramDurationSamples(t *testing.T) {


### PR DESCRIPTION
`sort.Search` returns `len(h.buckets)` when the value compares as not <= any bucket upper bound, which happens for `NaN` and `+Inf`, so `RecordValue` panics with an index out of range. This clamps the index to the last bucket. Closes #195.