### PR TITLE
test: add TestVersion and fix doc comment punctuation

### DIFF
--- a/scope.go
+++ b/scope.go
@@ -34,9 +34,9 @@ const (
 )
 
 var (
-	// NoopScope is a scope that does nothing
+	// NoopScope is a scope that does nothing.
 	NoopScope, _ = NewRootScope(ScopeOptions{Reporter: NullStatsReporter}, 0)
-	// DefaultSeparator is the default separator used to join nested scopes
+	// DefaultSeparator is the default separator used to join nested scopes.
 	DefaultSeparator = "."
 
 	globalNow = time.Now

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tally
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	assert.NotEmpty(t, Version)
+	assert.Equal(t, "4.1.17", Version)
+}


### PR DESCRIPTION
### Summary
- In `version_test.go`, add unit test `TestVersion` testing exported `tally.Version` constant.
- Add missing trailing periods to doc comments for `NoopScope` and `DefaultSeparator` in `scope.go`.