### PR TITLE
Add native histogram reporting to the reporter interfaces

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -69,6 +69,16 @@ func (r *printStatsReporter) ReportHistogramDurationSamples(
 		name, bucketLowerBound, bucketUpperBound, samples)
 }
 
+func (r *printStatsReporter) ReportNativeHistogram(
+	name string,
+	_ map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+	fmt.Printf("native histogram %s payload %d bytes samples %d\n",
+		name, len(payload), samples)
+}
+
 func (r *printStatsReporter) Capabilities() tally.Capabilities {
 	return r
 }

--- a/m3/reporter.go
+++ b/m3/reporter.go
@@ -134,6 +134,9 @@ type reporter struct {
 	numWriteErrors        atomic.Int64
 	numWriteErrorsCounter tally.CachedCount
 	numTagCacheCounter    tally.CachedCount
+
+	numNativeHistogramsDropped        atomic.Int64
+	numNativeHistogramsDroppedCounter tally.CachedCount
 }
 
 // Options is a set of options for the M3 reporter.
@@ -301,6 +304,9 @@ func NewReporter(opts Options) (Reporter, error) {
 	r.numMetricsCounter = r.AllocateCounter("tally.internal.num-metrics", internalTags)
 	r.numWriteErrorsCounter = r.AllocateCounter("tally.internal.num-write-errors", internalTags)
 	r.numTagCacheCounter = r.AllocateCounter("tally.internal.num-tag-cache", internalTags)
+	r.numNativeHistogramsDroppedCounter = r.AllocateCounter(
+		"tally.internal.num-native-histograms-dropped", internalTags,
+	)
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
@@ -439,6 +445,20 @@ func (r *reporter) AllocateHistogram(
 		cachedValueBuckets:    cachedValueBuckets,
 		cachedDurationBuckets: cachedDurationBuckets,
 	}
+}
+
+// AllocateNativeHistogram implements tally.CachedStatsReporter.
+//
+// The M3 thrift wire format carries only count, gauge and timer values, so
+// there is no field a serialized native histogram payload can travel in.
+// Rather than silently discard them, the returned handle counts every dropped
+// report into tally.internal.num-native-histograms-dropped.
+func (r *reporter) AllocateNativeHistogram(
+	name string,
+	tags map[string]string,
+	maxBuckets int,
+) tally.CachedNativeHistogram {
+	return cachedNativeHistogram{reporter: r}
 }
 
 func (r *reporter) valueBucketString(v float64) string {
@@ -699,6 +719,13 @@ func (r *reporter) reportInternalMetrics() {
 	r.numMetricsCounter.ReportCount(metrics)
 	r.numWriteErrorsCounter.ReportCount(writeErrors)
 	r.numTagCacheCounter.ReportCount(int64(r.tagCache.Len()))
+
+	// Reported only when non-zero. Emitting it unconditionally would add a
+	// permanently-zero series to every m3 reporter in a fleet, since almost
+	// no caller uses native histograms with this reporter.
+	if dropped := r.numNativeHistogramsDropped.Swap(0); dropped > 0 {
+		r.numNativeHistogramsDroppedCounter.ReportCount(dropped)
+	}
 }
 
 func (r *reporter) timeLoop() {
@@ -733,6 +760,16 @@ func (c cachedMetric) ReportGauge(value float64) {
 func (c cachedMetric) ReportTimer(interval time.Duration) {
 	c.metric.Value.Timer = int64(interval)
 	c.reporter.reportCopyMetric(c.metric, c.size, "", "")
+}
+
+// cachedNativeHistogram discards native histogram payloads, which the M3
+// thrift wire format cannot represent, and counts the drops.
+type cachedNativeHistogram struct {
+	reporter *reporter
+}
+
+func (c cachedNativeHistogram) ReportNativeHistogram(payload []byte, samples uint64) {
+	c.reporter.numNativeHistogramsDropped.Inc()
 }
 
 type noopMetric struct{}

--- a/multi/reporter.go
+++ b/multi/reporter.go
@@ -103,6 +103,17 @@ func (r *multi) ReportHistogramDurationSamples(
 	}
 }
 
+func (r *multi) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+	for _, r := range r.reporters {
+		r.ReportNativeHistogram(name, tags, payload, samples)
+	}
+}
+
 func (r *multi) Capabilities() tally.Capabilities {
 	return r.multiBaseReporters.Capabilities()
 }
@@ -175,6 +186,18 @@ func (r *multiCached) AllocateHistogram(
 	return multiMetric{histograms: metrics}
 }
 
+func (r *multiCached) AllocateNativeHistogram(
+	name string,
+	tags map[string]string,
+	maxBuckets int,
+) tally.CachedNativeHistogram {
+	metrics := make([]tally.CachedNativeHistogram, 0, len(r.reporters))
+	for _, r := range r.reporters {
+		metrics = append(metrics, r.AllocateNativeHistogram(name, tags, maxBuckets))
+	}
+	return multiMetric{nativeHistograms: metrics}
+}
+
 func (r *multiCached) Capabilities() tally.Capabilities {
 	return r.multiBaseReporters.Capabilities()
 }
@@ -184,10 +207,11 @@ func (r *multiCached) Flush() {
 }
 
 type multiMetric struct {
-	counters   []tally.CachedCount
-	gauges     []tally.CachedGauge
-	timers     []tally.CachedTimer
-	histograms []tally.CachedHistogram
+	counters         []tally.CachedCount
+	gauges           []tally.CachedGauge
+	timers           []tally.CachedTimer
+	histograms       []tally.CachedHistogram
+	nativeHistograms []tally.CachedNativeHistogram
 }
 
 func (m multiMetric) ReportCount(value int64) {
@@ -228,6 +252,12 @@ func (m multiMetric) DurationBucket(
 			m.DurationBucket(bucketLowerBound, bucketUpperBound))
 	}
 	return multiHistogramBucket{multi}
+}
+
+func (m multiMetric) ReportNativeHistogram(payload []byte, samples uint64) {
+	for _, m := range m.nativeHistograms {
+		m.ReportNativeHistogram(payload, samples)
+	}
 }
 
 type multiHistogramBucket struct {

--- a/multi/reporter_test.go
+++ b/multi/reporter_test.go
@@ -44,6 +44,7 @@ func TestMultiReporter(t *testing.T) {
 		{"foo": "qux"},
 		{"foo": "bzz"},
 		{"foo": "buz"},
+		{"foo": "nhg"},
 	}
 
 	valueBuckets := tally.MustMakeLinearValueBuckets(0, 2, 5)
@@ -57,6 +58,7 @@ func TestMultiReporter(t *testing.T) {
 		2.0, 4.0, 3)
 	r.ReportHistogramDurationSamples("buz", tags[4], durationBuckets,
 		2*time.Second, 4*time.Second, 3)
+	r.ReportNativeHistogram("nhg", tags[5], []byte("payload"), 7)
 	for _, r := range all {
 		require.Equal(t, 2, len(r.counts))
 
@@ -87,6 +89,12 @@ func TestMultiReporter(t *testing.T) {
 		assert.Equal(t, 2*time.Second, r.histogramDurationSamples[0].bucketLowerBound)
 		assert.Equal(t, 4*time.Second, r.histogramDurationSamples[0].bucketUpperBound)
 		assert.Equal(t, int64(3), r.histogramDurationSamples[0].samples)
+
+		require.Equal(t, 1, len(r.nativeHistograms))
+		assert.Equal(t, "nhg", r.nativeHistograms[0].name)
+		assert.Equal(t, tags[5], r.nativeHistograms[0].tags)
+		assert.Equal(t, []byte("payload"), r.nativeHistograms[0].payload)
+		assert.Equal(t, uint64(7), r.nativeHistograms[0].samples)
 	}
 
 	assert.NotNil(t, r.Capabilities())
@@ -112,6 +120,7 @@ func TestMultiCachedReporter(t *testing.T) {
 		{"foo": "qux"},
 		{"foo": "bzz"},
 		{"foo": "buz"},
+		{"foo": "nhg"},
 	}
 
 	valueBuckets := tally.MustMakeLinearValueBuckets(0, 2, 5)
@@ -132,6 +141,9 @@ func TestMultiCachedReporter(t *testing.T) {
 
 	dhist := r.AllocateHistogram("buz", tags[4], durationBuckets)
 	dhist.DurationBucket(2*time.Second, 4*time.Second).ReportSamples(3)
+
+	nhist := r.AllocateNativeHistogram("nhg", tags[5], 160)
+	nhist.ReportNativeHistogram([]byte("payload"), 7)
 
 	for _, r := range all {
 		require.Equal(t, 2, len(r.counts))
@@ -163,6 +175,12 @@ func TestMultiCachedReporter(t *testing.T) {
 		assert.Equal(t, 2*time.Second, r.histogramDurationSamples[0].bucketLowerBound)
 		assert.Equal(t, 4*time.Second, r.histogramDurationSamples[0].bucketUpperBound)
 		assert.Equal(t, int64(3), r.histogramDurationSamples[0].samples)
+
+		require.Equal(t, 1, len(r.nativeHistograms))
+		assert.Equal(t, "nhg", r.nativeHistograms[0].name)
+		assert.Equal(t, tags[5], r.nativeHistograms[0].tags)
+		assert.Equal(t, []byte("payload"), r.nativeHistograms[0].payload)
+		assert.Equal(t, uint64(7), r.nativeHistograms[0].samples)
 	}
 
 	assert.NotNil(t, r.Capabilities())
@@ -179,6 +197,7 @@ type capturingStatsReporter struct {
 	timers                   []capturedTimer
 	histogramValueSamples    []capturedHistogramValueSamples
 	histogramDurationSamples []capturedHistogramDurationSamples
+	nativeHistograms         []capturedNativeHistogram
 	capabilities             int
 	flush                    int
 }
@@ -215,6 +234,13 @@ type capturedHistogramDurationSamples struct {
 	bucketLowerBound time.Duration
 	bucketUpperBound time.Duration
 	samples          int64
+}
+
+type capturedNativeHistogram struct {
+	name    string
+	tags    map[string]string
+	payload []byte
+	samples uint64
 }
 
 func newCapturingStatsReporter() *capturingStatsReporter {
@@ -275,6 +301,16 @@ func (r *capturingStatsReporter) ReportHistogramDurationSamples(
 	r.histogramDurationSamples = append(r.histogramDurationSamples, elem)
 }
 
+func (r *capturingStatsReporter) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+	elem := capturedNativeHistogram{name, tags, payload, samples}
+	r.nativeHistograms = append(r.nativeHistograms, elem)
+}
+
 func (r *capturingStatsReporter) AllocateCounter(
 	name string,
 	tags map[string]string,
@@ -323,6 +359,17 @@ func (r *capturingStatsReporter) AllocateHistogram(
 	}
 }
 
+func (r *capturingStatsReporter) AllocateNativeHistogram(
+	name string,
+	tags map[string]string,
+	maxBuckets int,
+) tally.CachedNativeHistogram {
+	return cachedNativeHistogram{fn: func(payload []byte, samples uint64) {
+		elem := capturedNativeHistogram{name, tags, payload, samples}
+		r.nativeHistograms = append(r.nativeHistograms, elem)
+	}}
+}
+
 func (r *capturingStatsReporter) Capabilities() tally.Capabilities {
 	r.capabilities++
 	return r
@@ -362,6 +409,14 @@ type cachedTimer struct {
 
 func (c cachedTimer) ReportTimer(value time.Duration) {
 	c.fn(value)
+}
+
+type cachedNativeHistogram struct {
+	fn func(payload []byte, samples uint64)
+}
+
+func (h cachedNativeHistogram) ReportNativeHistogram(payload []byte, samples uint64) {
+	h.fn(payload, samples)
 }
 
 type cachedHistogram struct {

--- a/prometheus/reporter.go
+++ b/prometheus/reporter.go
@@ -216,6 +216,9 @@ func (m noopMetric) ReportCount(value int64)            {}
 func (m noopMetric) ReportGauge(value float64)          {}
 func (m noopMetric) ReportTimer(interval time.Duration) {}
 func (m noopMetric) ReportSamples(value int64)          {}
+
+func (m noopMetric) ReportNativeHistogram(payload []byte, samples uint64) {}
+
 func (m noopMetric) ValueBucket(lower, upper float64) tally.CachedHistogramBucket {
 	return m
 }
@@ -569,6 +572,21 @@ func (r *reporter) AllocateHistogram(
 		return noopMetric{}
 	}
 	return &cachedMetric{histogram: histogramVec.With(tags)}
+}
+
+// AllocateNativeHistogram implements tally.CachedStatsReporter.
+//
+// Prometheus has native histograms of its own, but tally hands this method an
+// already-serialized payload in whatever encoding the application chose via
+// ScopeOptions.NativeHistogramFactory. An opaque blob cannot be turned into a
+// prometheus.Collector, so there is nothing to register and the metric is
+// dropped.
+func (r *reporter) AllocateNativeHistogram(
+	name string,
+	tags map[string]string,
+	maxBuckets int,
+) tally.CachedNativeHistogram {
+	return noopMetric{}
 }
 
 func (r *reporter) Capabilities() tally.Capabilities {

--- a/reporter.go
+++ b/reporter.go
@@ -75,6 +75,16 @@ type StatsReporter interface {
 		bucketUpperBound time.Duration,
 		samples int64,
 	)
+
+	// ReportNativeHistogram reports a serialized native histogram covering
+	// the samples observed since the last report. The payload encoding is
+	// determined by the NativeHistogramData the scope was configured with.
+	ReportNativeHistogram(
+		name string,
+		tags map[string]string,
+		payload []byte,
+		samples uint64,
+	)
 }
 
 // CachedStatsReporter is a backend for Scopes that pre allocates all
@@ -107,6 +117,14 @@ type CachedStatsReporter interface {
 		tags map[string]string,
 		buckets Buckets,
 	) CachedHistogram
+
+	// AllocateNativeHistogram pre allocates a native histogram data structure
+	// with name, tags and a bucket budget.
+	AllocateNativeHistogram(
+		name string,
+		tags map[string]string,
+		maxBuckets int,
+	) CachedNativeHistogram
 }
 
 // CachedCount interface for reporting an individual counter
@@ -137,4 +155,14 @@ type CachedHistogram interface {
 // CachedHistogramBucket interface for reporting histogram samples to a specific bucket
 type CachedHistogramBucket interface {
 	ReportSamples(value int64)
+}
+
+// CachedNativeHistogram interface for reporting an individual native histogram.
+//
+// There is no per-bucket equivalent of CachedHistogramBucket: a native
+// histogram rescales its buckets as it observes values, so there is no stable
+// set of bounds to pre-allocate handles against. The whole distribution is
+// reported as one payload instead.
+type CachedNativeHistogram interface {
+	ReportNativeHistogram(payload []byte, samples uint64)
 }

--- a/scope_benchmark_test.go
+++ b/scope_benchmark_test.go
@@ -290,6 +290,8 @@ func (s noopStat) DurationBucket(bucketLowerBound, bucketUpperBound time.Duratio
 }
 func (s noopStat) ReportSamples(value int64) {}
 
+func (s noopStat) ReportNativeHistogram(payload []byte, samples uint64) {}
+
 type noopCachedReporter struct{}
 
 func (n noopCachedReporter) Capabilities() Capabilities {
@@ -311,6 +313,9 @@ func (n noopCachedReporter) ReportHistogramValueSamples(name string, tags map[st
 func (n noopCachedReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets Buckets, bucketLowerBound time.Duration, bucketUpperBound time.Duration, samples int64) {
 }
 
+func (n noopCachedReporter) ReportNativeHistogram(name string, tags map[string]string, payload []byte, samples uint64) {
+}
+
 func (n noopCachedReporter) AllocateCounter(name string, tags map[string]string) CachedCount {
 	return noopStat{}
 }
@@ -323,5 +328,9 @@ func (n noopCachedReporter) AllocateTimer(name string, tags map[string]string) C
 	return noopStat{}
 }
 func (n noopCachedReporter) AllocateHistogram(name string, tags map[string]string, buckets Buckets) CachedHistogram {
+	return noopStat{}
+}
+
+func (n noopCachedReporter) AllocateNativeHistogram(name string, tags map[string]string, maxBuckets int) CachedNativeHistogram {
 	return noopStat{}
 }

--- a/scope_test.go
+++ b/scope_test.go
@@ -100,18 +100,26 @@ func newTestHistogramValue() *testHistogramValue {
 	}
 }
 
+type testNativeHistogramValue struct {
+	tags    map[string]string
+	payload []byte
+	samples uint64
+}
+
 type testStatsReporter struct {
 	mtx sync.Mutex
 
-	cg sync.WaitGroup
-	gg sync.WaitGroup
-	tg sync.WaitGroup
-	hg sync.WaitGroup
+	cg  sync.WaitGroup
+	gg  sync.WaitGroup
+	tg  sync.WaitGroup
+	hg  sync.WaitGroup
+	nhg sync.WaitGroup
 
-	counters   map[string]*testIntValue
-	gauges     map[string]*testFloatValue
-	timers     map[string]*testIntValue
-	histograms map[string]*testHistogramValue
+	counters         map[string]*testIntValue
+	gauges           map[string]*testFloatValue
+	timers           map[string]*testIntValue
+	histograms       map[string]*testHistogramValue
+	nativeHistograms map[string]*testNativeHistogramValue
 
 	flushes int32
 }
@@ -119,10 +127,11 @@ type testStatsReporter struct {
 // newTestStatsReporter returns a new TestStatsReporter
 func newTestStatsReporter() *testStatsReporter {
 	return &testStatsReporter{
-		counters:   make(map[string]*testIntValue),
-		gauges:     make(map[string]*testFloatValue),
-		timers:     make(map[string]*testIntValue),
-		histograms: make(map[string]*testHistogramValue),
+		counters:         make(map[string]*testIntValue),
+		gauges:           make(map[string]*testFloatValue),
+		timers:           make(map[string]*testIntValue),
+		histograms:       make(map[string]*testHistogramValue),
+		nativeHistograms: make(map[string]*testNativeHistogramValue),
 	}
 }
 
@@ -211,6 +220,7 @@ func (r *testStatsReporter) WaitAll() {
 	r.gg.Wait()
 	r.tg.Wait()
 	r.hg.Wait()
+	r.nhg.Wait()
 }
 
 func (r *testStatsReporter) AllocateCounter(
@@ -386,6 +396,45 @@ func (r *testStatsReporter) ReportHistogramDurationSamples(
 	}
 	value.durationSamples[bucketUpperBound] = int(samples)
 	r.hg.Done()
+}
+
+func (r *testStatsReporter) AllocateNativeHistogram(
+	name string,
+	tags map[string]string,
+	maxBuckets int,
+) CachedNativeHistogram {
+	return testStatsReporterCachedNativeHistogram{r, name, tags}
+}
+
+type testStatsReporterCachedNativeHistogram struct {
+	r    *testStatsReporter
+	name string
+	tags map[string]string
+}
+
+func (h testStatsReporterCachedNativeHistogram) ReportNativeHistogram(
+	payload []byte,
+	samples uint64,
+) {
+	h.r.ReportNativeHistogram(h.name, h.tags, payload, samples)
+}
+
+func (r *testStatsReporter) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	key := KeyForPrefixedStringMap(name, tags)
+	r.nativeHistograms[key] = &testNativeHistogramValue{
+		tags:    tags,
+		payload: payload,
+		samples: samples,
+	}
+	r.nhg.Done()
 }
 
 func (r *testStatsReporter) Capabilities() Capabilities {

--- a/stats.go
+++ b/stats.go
@@ -249,6 +249,14 @@ func (r *timerNoReporterSink) ReportHistogramDurationSamples(
 ) {
 }
 
+func (r *timerNoReporterSink) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+}
+
 func (r *timerNoReporterSink) Capabilities() Capabilities {
 	return capabilitiesReportingTagging
 }
@@ -539,6 +547,14 @@ func (r nullStatsReporter) ReportHistogramDurationSamples(
 	bucketLowerBound,
 	bucketUpperBound time.Duration,
 	samples int64,
+) {
+}
+
+func (r nullStatsReporter) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
 ) {
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -29,10 +29,12 @@ import (
 )
 
 type statsTestReporter struct {
-	last            interface{}
-	valueSamples    map[float64]int
-	durationSamples map[time.Duration]int
-	buckets         Buckets
+	last                   interface{}
+	valueSamples           map[float64]int
+	durationSamples        map[time.Duration]int
+	buckets                Buckets
+	nativeHistogramPayload []byte
+	nativeHistogramSamples uint64
 }
 
 func newStatsTestReporter() *statsTestReporter {
@@ -75,6 +77,16 @@ func (r *statsTestReporter) ReportHistogramDurationSamples(
 ) {
 	r.durationSamples[bucketUpperBound] = int(samples)
 	r.buckets = buckets
+}
+
+func (r *statsTestReporter) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+	r.nativeHistogramPayload = payload
+	r.nativeHistogramSamples = samples
 }
 
 func (r *statsTestReporter) Capabilities() Capabilities {

--- a/statsd/reporter.go
+++ b/statsd/reporter.go
@@ -138,6 +138,18 @@ func (r *cactusStatsReporter) durationBucketString(
 	return upperBound.String()
 }
 
+// ReportNativeHistogram implements tally.StatsReporter.
+//
+// The statsd wire protocol carries scalar values only, so there is no way to
+// transmit a serialized native histogram payload and the metric is dropped.
+func (r *cactusStatsReporter) ReportNativeHistogram(
+	name string,
+	tags map[string]string,
+	payload []byte,
+	samples uint64,
+) {
+}
+
 func (r *cactusStatsReporter) Capabilities() tally.Capabilities {
 	return r
 }

--- a/tallymock/stats_reporter.go
+++ b/tallymock/stats_reporter.go
@@ -109,6 +109,18 @@ func (mr *MockStatsReporterMockRecorder) ReportHistogramValueSamples(arg0, arg1,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportHistogramValueSamples", reflect.TypeOf((*MockStatsReporter)(nil).ReportHistogramValueSamples), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// ReportNativeHistogram mocks base method.
+func (m *MockStatsReporter) ReportNativeHistogram(arg0 string, arg1 map[string]string, arg2 []byte, arg3 uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ReportNativeHistogram", arg0, arg1, arg2, arg3)
+}
+
+// ReportNativeHistogram indicates an expected call of ReportNativeHistogram.
+func (mr *MockStatsReporterMockRecorder) ReportNativeHistogram(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportNativeHistogram", reflect.TypeOf((*MockStatsReporter)(nil).ReportNativeHistogram), arg0, arg1, arg2, arg3)
+}
+
 // ReportTimer mocks base method.
 func (m *MockStatsReporter) ReportTimer(arg0 string, arg1 map[string]string, arg2 time.Duration) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Summary

This PR sets up the reporter side of tally. In order to add native histogram support in tally we have two sides that we need to make changes to, the Scope which is the user face that application code records to, and then the reporter side that ships metrics out. This PR lets tally's reporter side accept the native histogram (but not ship yet).

**Stack 1 of 4.** 
1. **Reporter interfaces** — #278 
2. The `NativeHistogram` type — #279
3. The `Scope` surface — #280
4. Module rename to `/v7` — #281

